### PR TITLE
Enable local stress testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+*.egg-info/
+*.pdf
+

--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@
   <div>&nbsp;</div>
 
 [![PyPI](https://img.shields.io/pypi/v/efemarai)](https://pypi.org/project/efemarai)
-[![license](https://img.shields.io/github/license/efemarai/efemarai.svg)](https://github.com/open-mmlab/mmdetection/blob/main/LICENSE)
+[![license](https://img.shields.io/github/license/efemarai/efemarai.svg)](https://github.com/efemarai/efemarai/blob/main/LICENSE)
 
  An SDK for interacting with the Efemarai ML [testing platform](https://ci.efemarai.com). Make your R&D model production ready.
 
     
 [📘Documentation](https://ci.efemarai.com/docs) |
-[🛠️Installation](https://ci.efemarai.com/86b41a59036d7a2bcb53feb925444603/tutorials/getting_started.html#getting-started) |
+[🛠️Installation](https://ci.efemarai.com/docs/tutorials/getting_started.html#getting-started) |
 [👀Break YOLO](https://breakyolo.efemarai.com/) |
-[🚀Join Community](https://discord.gg/cWQC3rrB) |
+[🚀Join Community](https://discord.gg/zXsVgSuemB) |
 [😞Reporting Issues](https://github.com/efemarai/efemarai/issues/new/choose)
 
 </div>
@@ -113,7 +113,7 @@ dataset = project.create_dataset(
     format=ef.DatasetFormat.COCO,
 )
 ```
-If your dataset is remote or part of an existing database with custom formats, you can easily upload it to the system by (1) iterating over the dataset and (2) creating datapoints containing the images and required targets. You can find a code example [here](https://ci.efemarai.com/86b41a59036d7a2bcb53feb925444603/tutorials/how_to/project_bounding_box.html#create-dataset).
+If your dataset is remote or part of an existing database with custom formats, you can easily upload it to the system by (1) iterating over the dataset and (2) creating datapoints containing the images and required targets. You can find a code example [here](https://ci.efemarai.com/docs/tutorials/how_to/project_bounding_box.html#create-dataset).
 
 After wrapping up any processing, you can confirm the status in the UI and explore the inputs and annotations.
 
@@ -226,7 +226,7 @@ Let's use the UI to quickly create a domain (`Example`) that you expect your mod
 
 ![](https://storage.googleapis.com/public-efemarai/domain2.gif)
 
-You can find more information in the [docs](https://ci.efemarai.com/86b41a59036d7a2bcb53feb925444603/tutorials/step_by_step/domain.html#create-domain).
+You can find more information in the [docs](https://ci.efemarai.com/docs/tutorials/step_by_step/domain.html#create-domain).
 
 ### Working with stress tests
 

--- a/efemarai/__init__.py
+++ b/efemarai/__init__.py
@@ -8,6 +8,7 @@ from efemarai.fields import (
     InstanceMask,
     Keypoint,
     Mask,
+    ModelOutput,
     Polygon,
     Skeleton,
     Tag,
@@ -17,5 +18,13 @@ from efemarai.fields import (
     VideoFrame,
 )
 from efemarai.session import Session
+
+from efemarai.metamorph.search_domain import test_robustness
+
+import efemarai.spec
+import efemarai.formats
+import efemarai.hooks
+import efemarai.reports
+import efemarai.domains
 
 __version__ = "0.3.5"

--- a/efemarai/definition_checker.py
+++ b/efemarai/definition_checker.py
@@ -26,9 +26,10 @@ class DefinitionChecker(BaseChecker):
     def is_path_remote(path):
         return urllib.parse.urlparse(path).scheme in ("http", "https")
 
-    def load_definition(self, filename):
+    @staticmethod
+    def load_definition(filename):
         if not os.path.isfile(filename):
-            self._error(f"File '{filename}' does not exist")
+            BaseChecker._error(f"File '{filename}' does not exist")
 
         with open(filename) as f:
             contents = f.read()
@@ -39,11 +40,13 @@ class DefinitionChecker(BaseChecker):
         )
 
         unknown_environment_variables = list(
-            set(unknown_environment_variables) - self._allowed_vars
+            set(unknown_environment_variables) - DefinitionChecker._allowed_vars
         )
         if unknown_environment_variables:
             for match in unknown_environment_variables:
-                self._error(f"Unknown environment variable '{match}' in '{filename}'")
+                BaseChecker._error(
+                    f"Unknown environment variable '{match}' in '{filename}'"
+                )
 
         return yaml.safe_load(contents)
 

--- a/efemarai/domains/__init__.py
+++ b/efemarai/domains/__init__.py
@@ -1,0 +1,18 @@
+import os
+
+from efemarai.definition_checker import DefinitionChecker
+from efemarai.metamorph.domain_loader import DomainLoader
+
+
+def load(filename, dataset=None):
+    definition = DefinitionChecker.load_definition(filename).get("domains")
+
+    if definition is None or not definition:
+        return None
+
+    return DomainLoader.load(definition[0], dataset)
+
+
+GeometricVariability = load(os.path.dirname(__file__) + "/geometric.yaml")
+ColorVariability = load(os.path.dirname(__file__) + "/color.yaml")
+NoiseVariability = load(os.path.dirname(__file__) + "/noise.yaml")

--- a/efemarai/domains/color.yaml
+++ b/efemarai/domains/color.yaml
@@ -1,0 +1,132 @@
+domains:
+
+
+- name: ColorStyle
+  transformations:
+
+  - name: ChooseImage
+    operator: ChooseImage
+    axes:
+
+    - name: dataset
+      type: str
+      range: []
+      choices: []
+      fixed: true
+      value: ''
+
+    - name: classes
+      type: list
+      range: []
+      choices: []
+      fixed: true
+      value: []
+    inputs: []
+    outputs:
+    - type: Datapoint
+      input_to:
+      - transformation: BrightnessContrast
+        index: 0
+    position:
+      x: -20
+      "y": 0
+
+  - name: EvaluateSample
+    operator: EvaluateSample
+    axes: []
+    inputs:
+    - type: Datapoint
+      output_from:
+        transformation: ShiftHSV
+        index: 0
+    outputs: []
+    position:
+      x: 748
+      "y": 0
+
+  - name: BrightnessContrast
+    operator: BrightnessContrast
+    axes:
+
+    - name: brightness
+      type: float
+      range: [-0.1, 0.1]
+      choices: []
+      fixed: false
+
+    - name: contrast
+      type: float
+      range: [-0.1, 0.1]
+      choices: []
+      fixed: false
+    inputs:
+    - type: Datapoint
+      output_from:
+        transformation: ChooseImage
+        index: 0
+    outputs:
+    - type: Datapoint
+      input_to:
+      - transformation: Gamma
+        index: 0
+    position:
+      x: 165
+      "y": 0
+
+  - name: Gamma
+    operator: Gamma
+    axes:
+
+    - name: gamma
+      type: float
+      range: [0.9, 1.1]
+      choices: []
+      fixed: false
+    inputs:
+    - type: Datapoint
+      output_from:
+        transformation: BrightnessContrast
+        index: 0
+    outputs:
+    - type: Datapoint
+      input_to:
+      - transformation: ShiftHSV
+        index: 0
+    position:
+      x: 394
+      "y": 0
+
+  - name: ShiftHSV
+    operator: ShiftHSV
+    axes:
+
+    - name: hue
+      type: int
+      range: [-15, 15]
+      choices: []
+      fixed: false
+
+    - name: sat
+      type: int
+      range: [-15, 15]
+      choices: []
+      fixed: false
+
+    - name: val
+      type: int
+      range: [-15, 15]
+      choices: []
+      fixed: false
+    inputs:
+    - type: Datapoint
+      output_from:
+        transformation: Gamma
+        index: 0
+    outputs:
+    - type: Datapoint
+      input_to:
+      - transformation: EvaluateSample
+        index: 0
+    position:
+      x: 567
+      "y": 0

--- a/efemarai/domains/geometric.yaml
+++ b/efemarai/domains/geometric.yaml
@@ -1,0 +1,222 @@
+domains:
+
+
+- name: Test
+  transformations:
+
+  - name: ChooseImage
+    operator: ChooseImage
+    axes:
+
+    - name: dataset
+      type: str
+      range: []
+      choices: []
+      fixed: true
+      value: ''
+
+    - name: classes
+      type: list
+      range: []
+      choices: []
+      fixed: true
+      value: []
+    inputs: []
+    outputs:
+    - type: Datapoint
+      input_to:
+      - transformation: HorizontalFlip
+        index: 0
+    position:
+      x: -262
+      "y": -37
+
+  - name: Affine
+    operator: Affine
+    axes:
+
+    - name: affine_scale
+      type: float
+      range: [0.9, 1.1]
+      choices: []
+      fixed: false
+      value: 1
+
+    - name: shear_x
+      type: float
+      range: [-10, 10]
+      choices: []
+      fixed: true
+      value: 0
+
+    - name: shear_y
+      type: float
+      range: [-40, 40]
+      choices: []
+      fixed: true
+      value: 0
+
+    - name: affine_rotate
+      type: float
+      range: [-10, 10]
+      choices: []
+      fixed: false
+      value: 0
+
+    - name: translate_x
+      type: float
+      range: []
+      choices: []
+      fixed: true
+      value: 0
+
+    - name: translate_y
+      type: float
+      range: []
+      choices: []
+      fixed: true
+      value: 0
+
+    - name: interpolation
+      type: int
+      range: []
+      choices: []
+      fixed: true
+      value: 1
+
+    - name: border_mode
+      type: int
+      range: []
+      choices: []
+      fixed: true
+      value: 1
+
+    - name: infill_color
+      type: Color
+      range: []
+      choices: []
+      fixed: true
+      value: [0, 0, 0]
+    inputs:
+    - type: Datapoint
+      output_from:
+        transformation: HorizontalFlip
+        index: 0
+    outputs:
+    - type: Datapoint
+      input_to:
+      - transformation: Perspective
+        index: 0
+    position:
+      x: 127
+      "y": -9
+
+  - name: EvaluateSample
+    operator: EvaluateSample
+    axes: []
+    inputs:
+    - type: Datapoint
+      output_from:
+        transformation: OpticalDistortion
+        index: 0
+    outputs: []
+    position:
+      x: 737
+      "y": -7
+
+  - name: Perspective
+    operator: Perspective
+    axes:
+
+    - name: perspective_scale
+      type: float
+      range: [0, 0.1]
+      choices: []
+      fixed: false
+
+    - name: border_mode
+      type: int
+      range: []
+      choices: [0, 1, 2, 3, 4]
+      fixed: true
+      value: 0
+    inputs:
+    - type: Datapoint
+      output_from:
+        transformation: Affine
+        index: 0
+    outputs:
+    - type: Datapoint
+      input_to:
+      - transformation: OpticalDistortion
+        index: 0
+    position:
+      x: 298
+      "y": -7
+
+  - name: OpticalDistortion
+    operator: OpticalDistortion
+    axes:
+
+    - name: distort_limit
+      type: float
+      range: [-0.1, 0.1]
+      choices: []
+      fixed: false
+
+    - name: distort_shift_limit
+      type: float
+      range: [-10, 10]
+      choices: []
+      fixed: true
+      value: 1
+
+    - name: border_mode
+      type: int
+      range: []
+      choices: [0, 1, 2, 3, 4]
+      fixed: true
+      value: 4
+
+    - name: interpolation
+      type: int
+      range: []
+      choices: [0, 1, 2, 3, 4]
+      fixed: true
+      value: 1
+    inputs:
+    - type: Datapoint
+      output_from:
+        transformation: Perspective
+        index: 0
+    outputs:
+    - type: Datapoint
+      input_to:
+      - transformation: EvaluateSample
+        index: 0
+    position:
+      x: 506
+      "y": -4
+
+  - name: HorizontalFlip
+    operator: HorizontalFlip
+    axes:
+
+    - name: hflip
+      type: bool
+      range: []
+      choices: [false, true]
+      fixed: false
+    inputs:
+    - type: Datapoint
+      output_from:
+        transformation: ChooseImage
+        index: 0
+    outputs:
+    - type: Datapoint
+      input_to:
+      - transformation: Affine
+        index: 0
+    position:
+      x: -76
+      "y": -22

--- a/efemarai/domains/noise.yaml
+++ b/efemarai/domains/noise.yaml
@@ -1,0 +1,164 @@
+domains:
+
+
+- name: Noise
+  transformations:
+
+  - name: ChooseImage
+    operator: ChooseImage
+    axes:
+
+    - name: dataset
+      type: str
+      range: []
+      choices: []
+      fixed: true
+      value: ''
+
+    - name: classes
+      type: list
+      range: []
+      choices: []
+      fixed: true
+      value: []
+    inputs: []
+    outputs:
+    - type: Datapoint
+      input_to:
+      - transformation: ISONoise
+        index: 0
+    position:
+      x: -340
+      "y": 0
+
+  - name: EvaluateSample
+    operator: EvaluateSample
+    axes: []
+    inputs:
+    - type: Datapoint
+      output_from:
+        transformation: Sharpen
+        index: 0
+    outputs: []
+    position:
+      x: 660
+      "y": 0
+
+  - name: ISONoise
+    operator: ISONoise
+    axes:
+
+    - name: iso_color_shift
+      type: float
+      range: [0, 0.6]
+      choices: []
+      fixed: false
+
+    - name: iso_intensity
+      type: float
+      range: [0, 1]
+      choices: []
+      fixed: true
+      value: 0.5
+    inputs:
+    - type: Datapoint
+      output_from:
+        transformation: ChooseImage
+        index: 0
+    outputs:
+    - type: Datapoint
+      input_to:
+      - transformation: MotionBlur
+        index: 0
+    position:
+      x: -150
+      "y": 0
+
+  - name: MotionBlur
+    operator: MotionBlur
+    axes:
+
+    - name: motion_blur
+      type: int
+      range: [0, 10]
+      choices: []
+      fixed: false
+
+    - name: motion_direction
+      type: float
+      range: [0, 1]
+      choices: []
+      fixed: false
+    inputs:
+    - type: Datapoint
+      output_from:
+        transformation: ISONoise
+        index: 0
+    outputs:
+    - type: Datapoint
+      input_to:
+      - transformation: ImageCompression
+        index: 0
+    position:
+      x: 25
+      "y": 0
+
+  - name: ImageCompression
+    operator: ImageCompression
+    axes:
+
+    - name: image_quality
+      type: int
+      range: [40, 100]
+      choices: []
+      fixed: false
+
+    - name: compression_type
+      type: str
+      range: []
+      choices: [jpg, webp]
+      fixed: true
+      value: jpg
+    inputs:
+    - type: Datapoint
+      output_from:
+        transformation: MotionBlur
+        index: 0
+    outputs:
+    - type: Datapoint
+      input_to:
+      - transformation: Sharpen
+        index: 0
+    position:
+      x: 215
+      "y": 0
+
+  - name: Sharpen
+    operator: Sharpen
+    axes:
+
+    - name: sharpen_alpha
+      type: float
+      range: [0, 0.8]
+      choices: []
+      fixed: false
+
+    - name: sharpen_lightness
+      type: float
+      range: [0, 1]
+      choices: []
+      fixed: true
+      value: 1
+    inputs:
+    - type: Datapoint
+      output_from:
+        transformation: ImageCompression
+        index: 0
+    outputs:
+    - type: Datapoint
+      input_to:
+      - transformation: EvaluateSample
+        index: 0
+    position:
+      x: 465
+      "y": 0

--- a/efemarai/fields/__init__.py
+++ b/efemarai/fields/__init__.py
@@ -28,7 +28,7 @@ from efemarai.fields.data_fields import (
     VideoFrame,
     create_polygons_from_mask,
 )
-from efemarai.fields.datapoint import Datapoint
+from efemarai.fields.datapoint import Datapoint, ModelOutput
 
 SDK_CLASS_STRUCTURE = dict(inspect.getmembers(sys.modules[__name__], inspect.isclass))
 

--- a/efemarai/fields/annotation_fields.py
+++ b/efemarai/fields/annotation_fields.py
@@ -287,6 +287,40 @@ class InstanceField(BaseField):
 
 
 class BoundingBox(InstanceField):
+    XYWH_ABSOLUTE = 0
+    XYXY_ABSOLUTE = 1
+
+    @staticmethod
+    def convert(box, source_format=None, target_format=None):
+        if source_format is None:
+            source_format = BoundingBox.XYXY_ABSOLUTE
+
+        if target_format is None:
+            target_format = BoundingBox.XYXY_ABSOLUTE
+
+        if source_format == target_format:
+            return box
+
+        if source_format != BoundingBox.XYXY_ABSOLUTE:
+            box = BoundingBox._convert_to_xyxy_absolute(box, source_format)
+
+        if target_format != BoundingBox.XYXY_ABSOLUTE:
+            box = BoundingBox._convert_from_xyxy_absolute(box, target_format)
+
+        return box
+
+    @staticmethod
+    def _convert_to_xyxy_absolute(box, source_format):
+        if source_format == BoundingBox.XYWH_ABSOLUTE:
+            x, y, w, h, *rest = box
+            return x, y, x + w - 1, y + h - 1, *rest
+
+    @staticmethod
+    def _convert_from_xyxy_absolute(box, target_format):
+        if target_format == BoundingBox.XYWH_ABSOLUTE:
+            x1, y1, x2, y2, *rest = box
+            return x1, y2, x2 - x1 + 1, y2 - y1 + 1, *rest
+
     """
     Represents a bounding box annotation.
 

--- a/efemarai/fields/base_fields.py
+++ b/efemarai/fields/base_fields.py
@@ -65,6 +65,8 @@ class BaseField:
     ):
 
         self.id = id if id is not None else ObjectId()
+        self._requires_loss = True
+        self._requires_transform = True
         self.description = description
         self.key_name = key_name
         self.confidence = confidence

--- a/efemarai/formats/__init__.py
+++ b/efemarai/formats/__init__.py
@@ -1,0 +1,38 @@
+import numpy as np
+from PIL import Image as PIL_Image
+
+from efemarai.fields import AnnotationClass, BoundingBox, Image
+from efemarai.spec import call, create
+
+
+def tensor_to_numpy(x):
+    return x.detach().cpu().numpy()
+
+
+COCO_INPUT = create(Image, data=np.array, key_name="'image'")
+
+COCO_TARGET = [
+    create(
+        BoundingBox,
+        label=create(AnnotationClass, id="category_id"),
+        xyxy=call(
+            BoundingBox.convert,
+            box="bbox",
+            source_format=BoundingBox.XYWH_ABSOLUTE,
+        ),
+    )
+]
+
+COCO_DATASET = (COCO_INPUT, COCO_TARGET)
+
+DEFAULT_INPUT_FORMAT = {".image": {".data": PIL_Image.fromarray}}
+
+TORCHVISION_DETECTION = {
+    call(zip, "boxes", "labels"): [
+        create(
+            BoundingBox,
+            xyxy={0: tensor_to_numpy},
+            label=create(AnnotationClass, id={1: tensor_to_numpy}),
+        )
+    ]
+}

--- a/efemarai/hooks.py
+++ b/efemarai/hooks.py
@@ -1,0 +1,33 @@
+from efemarai.fields import BoundingBox
+
+
+def show_sample(
+    original_datapoint,
+    generated_datapoint,
+    model_output,
+    baseline_loss,
+    sample_loss,
+    delta_score,
+):
+    import cv2
+    import numpy as np
+
+    image = np.array(generated_datapoint.image.data[:, :, ::-1])
+    cv2.putText(
+        image,
+        f"{delta_score:.4f}",
+        (20, 40),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        1,
+        (255, 255, 255),
+        2,
+        cv2.LINE_AA,
+    )
+
+    boxes = [field for field in model_output.outputs if isinstance(field, BoundingBox)]
+    for box in boxes:
+        x1, y1, x2, y2 = box.xyxy
+        cv2.rectangle(image, (int(x1), int(y1)), (int(x2), int(y2)), (255, 255, 255), 1)
+
+    cv2.imshow(f"Generated Image", image)
+    cv2.waitKey(1)

--- a/efemarai/metamorph/__init__.py
+++ b/efemarai/metamorph/__init__.py
@@ -1,0 +1,1 @@
+from efemarai.metamorph.vision.vision_metamorphs import Box, Color

--- a/efemarai/metamorph/adaptors.py
+++ b/efemarai/metamorph/adaptors.py
@@ -1,0 +1,514 @@
+import random
+from copy import deepcopy
+from functools import wraps
+
+import albumentations as A
+import numpy as np
+
+from efemarai import BoundingBox, Image, Keypoint, Polygon, Skeleton
+
+
+def apply_albumentation(filter_instances=True):
+    def decorator(create_operator):
+        supported_data_types = {Image}
+        supported_annotation_types = {BoundingBox, Polygon, Keypoint, Skeleton}
+
+        @wraps(create_operator)
+        def wrapper(*args, **kwargs):
+            def apply_operator(datapoint):
+
+                # Specify how a single field is to be transformed
+                def transform(field, annotations, field_metadata=None):
+                    operator = create_operator(*args, **kwargs)
+                    input_targets = prepare_targets(field, annotations)
+                    output_targets = operator(**input_targets)
+
+                    if filter_instances:
+                        output_targets = filter_targets(output_targets)
+
+                    image, annotations = prepare_fields(output_targets)
+                    image.key_name = field.key_name
+
+                    return image, annotations
+
+                result = transform_datapoint(
+                    transform,
+                    datapoint,
+                    supported_data_types,
+                    supported_annotation_types,
+                )
+
+                return (result,)
+
+            return apply_operator
+
+        return wrapper
+
+    return decorator
+
+
+def apply_paste():
+    def decorator(create_operator):
+        supported_data_types = {Image}
+        supported_annotation_types = {BoundingBox, Polygon, Keypoint, Skeleton}
+
+        @wraps(create_operator)
+        def wrapper(*args, **kwargs):
+            def apply_operator(asset, datapoint):
+
+                # Specify how a single field is to be transformed
+                def transform(field, annotations, field_metadata):
+                    paste = create_operator(*args, **kwargs)
+                    image, annotations = paste(
+                        asset, field, annotations, field_metadata
+                    )
+                    return image, annotations
+
+                result = transform_datapoint(
+                    transform,
+                    datapoint,
+                    supported_data_types,
+                    supported_annotation_types,
+                )
+
+                return (result,)
+
+            return apply_operator
+
+        return wrapper
+
+    return decorator
+
+
+def transform_datapoint(
+    transform,
+    datapoint,
+    supported_data_types,
+    supported_annotation_types,
+):
+    result = datapoint.__class__(
+        dataset=datapoint.dataset,
+        # TODO: Figure out how to handle metadata
+        # metadata=deepcopy(datapoint.metadata),
+        # synthetic=True,
+    )
+
+    seed = random.randint(0, (1 << 32) - 1)
+
+    id_swaps = {}
+    processed_annotations = set()
+
+    for field in datapoint.inputs:
+        # print("Field:::", field)
+        # print("annotation:::", datapoint.targets)
+        annotations = [
+            annotation
+            for annotation in datapoint.targets
+            if field.id in annotation.ref_field
+        ]
+
+        # Make sure to process annotations just once
+        annotations = [
+            annotation
+            for annotation in annotations
+            if annotation.id not in processed_annotations
+        ]
+        processed_annotations.update([annotation.id for annotation in annotations])
+
+        random.seed(seed)
+
+        field_metadata = [
+            # metadata_field
+            # for metadata_field in datapoint.metadata
+            # if field.id in metadata_field.ref_field
+        ]
+
+        transformed_field, transformed_annotations = transform_field(
+            transform,
+            field,
+            annotations,
+            field_metadata,
+            supported_data_types,
+            supported_annotation_types,
+        )
+
+        id_swaps[field.id] = transformed_field.id
+
+        result.inputs.append(transformed_field)
+        result.targets.extend(transformed_annotations)
+
+    for target in result.targets:
+        target.ref_field = [id_swaps.get(ref, ref) for ref in target.ref_field]
+
+    random.seed()
+
+    return result
+
+
+def transform_field(
+    transform,
+    field,
+    annotations,
+    field_metadata,
+    supported_data_types,
+    supported_annotation_types,
+):
+    # Skip fields that are not to be transformed
+    field_supported = type(field) in supported_data_types
+    requires_transform = field._requires_transform
+    if not field_supported or not requires_transform:
+        return deepcopy(field), deepcopy(annotations)
+
+    # Split annotations into un/supported
+    supported_annotations = []
+    unsupported_annotations = []
+    for annotation in annotations:
+        if type(annotation) in supported_annotation_types:
+            supported_annotations.append(annotation)
+        else:
+            unsupported_annotations.append(annotation)
+
+    # Transform field and supported annotations
+    transformed_field, transformed_annotations = transform(
+        field, supported_annotations, field_metadata
+    )
+
+    # Update ref_field of unsupported annotations
+    for annotation in unsupported_annotations:
+        annotation = deepcopy(annotation)
+        transformed_annotations.append(annotation)
+
+    return transformed_field, transformed_annotations
+
+
+def prepare_targets(image, annotations):
+    """Convert an image and its annotations to an albumentation targets."""
+    height, width = image.data.shape[:2]
+
+    box_fields = [field for field in annotations if type(field) is BoundingBox]
+    boxes = [
+        A.core.bbox_utils.convert_bbox_to_albumentations(
+            bbox=box.xyxy,
+            source_format="pascal_voc",
+            rows=height,
+            cols=width,
+        )
+        for box in box_fields
+    ]
+
+    polygon_fields = [field for field in annotations if type(field) is Polygon]
+    masks = [polygon.get_mask(image.width, image.height) for polygon in polygon_fields]
+
+    keypoint_fields = [field for field in annotations if type(field) is Keypoint]
+    skeleton_fields = [field for field in annotations if type(field) is Skeleton]
+
+    keypoints = [
+        A.core.keypoints_utils.convert_keypoint_to_albumentations(
+            keypoint=keypoint.to_xy(),
+            source_format="xy",
+            rows=height,
+            cols=width,
+        )
+        for keypoint in keypoint_fields
+    ]
+
+    for skeleton in skeleton_fields:
+        keypoints.extend(
+            A.core.keypoints_utils.convert_keypoints_to_albumentations(
+                keypoints=skeleton.to_xy(),
+                source_format="xy",
+                rows=height,
+                cols=width,
+            )
+        )
+
+    targets = {"image": image.data}
+
+    if boxes:
+        targets["bboxes"] = boxes
+        targets["box_fields"] = box_fields
+
+    if masks:
+        targets["masks"] = masks
+        targets["polygon_fields"] = polygon_fields
+
+    if keypoints:
+        targets["keypoints"] = keypoints
+        targets["keypoint_fields"] = keypoint_fields
+        targets["skeleton_fields"] = skeleton_fields
+
+    return targets
+
+
+def filter_targets(targets):
+    """Remove annotations that are empty or outside of the image."""
+    removed_instance_ids = remove_instances(targets)
+
+    filtered_targets = {"image": targets["image"]}
+
+    if "bboxes" in targets:
+        boxes = []
+        box_fields = []
+
+        for bbox, field in zip(targets["bboxes"], targets["box_fields"]):
+            if field.instance_id not in removed_instance_ids:
+                boxes.append(bbox)
+                box_fields.append(field)
+
+        filtered_targets["bboxes"] = boxes
+        filtered_targets["box_fields"] = box_fields
+
+    if "masks" in targets:
+        masks = []
+        polygon_fields = []
+        for mask, field in zip(targets["masks"], targets["polygon_fields"]):
+            if field.instance_id not in removed_instance_ids:
+                masks.append(mask)
+                polygon_fields.append(field)
+
+        filtered_targets["masks"] = masks
+        filtered_targets["polygon_fields"] = polygon_fields
+
+    if "keypoints" in targets:
+        keypoints = []
+        keypoint_fields = []
+        skeleton_fields = []
+
+        for keypoint, field in zip(targets["keypoints"], targets["keypoint_fields"]):
+            if field.instance_id not in removed_instance_ids:
+                keypoints.append(keypoint)
+                keypoint_fields.append(field)
+
+        start_index = len(targets["keypoint_fields"])
+        for field in targets["skeleton_fields"]:
+            end_index = start_index + len(field.keypoints)
+
+            if field.instance_id not in removed_instance_ids:
+                keypoints.extend(targets["keypoints"][start_index:end_index])
+                skeleton_fields.append(field)
+
+            start_index = end_index
+
+        filtered_targets["keypoints"] = keypoints
+        filtered_targets["keypoint_fields"] = keypoint_fields
+        filtered_targets["skeleton_fields"] = skeleton_fields
+
+    return filtered_targets
+
+
+def remove_instances(targets):
+    """Get the IDs of instances that are outside of the image or have empty annotations."""
+    height, width = targets["image"].shape[:2]
+
+    removed_instance_ids = set()
+
+    # Remove instances with bounding boxes outside of the image
+    if "box_fields" in targets:
+        for bbox, field in zip(targets["bboxes"], targets["box_fields"]):
+            x1, y1, x2, y2 = bbox
+            if x2 < 0 or width < x1 or y2 < 0 or height < y1:
+                removed_instance_ids.add(field.instance_id)
+
+    # Remove instances with empty masks
+    if "polygon_fields" in targets:
+        for mask, field in zip(targets["masks"], targets["polygon_fields"]):
+            if np.count_nonzero(mask) == 0:
+                removed_instance_ids.add(field.instance_id)
+
+    # Remove instances with all keypoints outside of the image
+    if "keypoint_fields" in targets:
+        inside_instance_ids = set()
+        outside_instance_ids = set()
+        for keypoint, field in zip(targets["keypoints"], targets["keypoint_fields"]):
+            x, y, *_ = keypoint
+            if not field.annotated:
+                continue
+
+            if x < 0 or width < x or y < 0 or height < y:
+                outside_instance_ids.add(field.instance_id)
+            else:
+                inside_instance_ids.add(field.instance_id)
+
+        for instance_id in outside_instance_ids:
+            if instance_id not in inside_instance_ids:
+                removed_instance_ids.add(instance_id)
+
+    # Remove instances with skeletons completely outside of the image
+    if "skeleton_fields" in targets:
+        start_index = len(targets["keypoint_fields"])
+        for skeleton in targets["skeleton_fields"]:
+            end_index = start_index + len(skeleton.keypoints)
+
+            # Get all annotated keypoints
+            keypoints = np.array(
+                [
+                    keypoint
+                    for keypoint, field in zip(
+                        targets["keypoints"][start_index:end_index], skeleton.keypoints
+                    )
+                    if field.annotated
+                ]
+            )
+
+            # Do not remove an instance based on keypoints if none of them are annotated
+            if len(keypoints) == 0:
+                continue
+
+            x1, y1, *_ = keypoints.min(axis=0)
+            x2, y2, *_ = keypoints.max(axis=0)
+
+            if x2 < 0 or width < x1 or y2 < 0 or height < y1:
+                removed_instance_ids.add(skeleton.instance_id)
+
+            start_index = end_index
+
+    return removed_instance_ids
+
+
+def prepare_fields(targets):
+    """Convert albumentation targets to datapoint fields."""
+    height, width = targets["image"].shape[:2]
+    image = Image(width=width, height=height, data=targets["image"])
+
+    annotations = []
+    annotations.extend(prepare_box_fields(image, targets))
+    annotations.extend(prepare_polygon_fields(image, targets))
+    annotations.extend(prepare_keypoint_fields(image, targets))
+    annotations.extend(prepare_skeleton_fields(image, targets))
+
+    return image, annotations
+
+
+def prepare_box_fields(image, targets):
+    if "bboxes" not in targets:
+        return []
+
+    box_fields = []
+
+    for bbox, field in zip(targets["bboxes"], targets["box_fields"]):
+        x1, y1, x2, y2 = A.core.bbox_utils.convert_bbox_from_albumentations(
+            bbox=bbox,
+            target_format="pascal_voc",
+            rows=image.height,
+            cols=image.width,
+        )
+
+        # Make sure boxes raimain within the image
+        def clip_x(x):
+            return max(0, min(x, image.width))
+
+        def clip_y(y):
+            return max(0, min(y, image.height))
+
+        x1, y1, x2, y2 = clip_x(x1), clip_y(y1), clip_x(x2), clip_y(y2)
+
+        area = (x2 - x1 + 1) * (y2 - y1 + 1)
+        box_fields.append(
+            BoundingBox(
+                xyxy=[x1, y1, x2, y2],
+                area=area,
+                ref_field=[image.id],
+                instance_id=field.instance_id,
+                label=field.label,
+            )
+        )
+
+    return box_fields
+
+
+def prepare_polygon_fields(image, targets):
+    if "masks" not in targets:
+        return []
+
+    polygon_fields = []
+
+    for mask, field in zip(targets["masks"], targets["polygon_fields"]):
+        polygon = Polygon(
+            ref_field=[image.id],
+            instance_id=field.instance_id,
+            label=field.label,
+        )
+        polygon.set_mask(mask)
+        polygon.set_vertices()
+        polygon_fields.append(polygon)
+
+    return polygon_fields
+
+
+def prepare_keypoint_fields(image, targets):
+    if "keypoints" not in targets:
+        return []
+
+    keypoint_fields = targets["keypoint_fields"]
+    keypoints = A.core.keypoints_utils.convert_keypoints_from_albumentations(
+        keypoints=targets["keypoints"][: len(keypoint_fields)],
+        target_format="xy",
+        rows=image.height,
+        cols=image.width,
+    )
+
+    return [
+        Keypoint(
+            ref_field=[image.id],
+            instance_id=field.instance_id,
+            label=field.label,
+            x=x,
+            y=y,
+            name=field.name,
+            index=field.index,
+            annotated=field.annotated,
+            occluded=field.occluded,
+        )
+        for (x, y), field in zip(keypoints, keypoint_fields)
+    ]
+
+
+def prepare_skeleton_fields(image, targets):
+    if "keypoints" not in targets:
+        return []
+
+    skeleton_fields = []
+
+    # Skip keypoints corresponding to plain keypoint fields
+    start_index = len(targets["keypoint_fields"])
+
+    for skeleton in targets["skeleton_fields"]:
+        end_index = start_index + len(skeleton.keypoints)
+        keypoints = A.core.keypoints_utils.convert_keypoints_from_albumentations(
+            keypoints=targets["keypoints"][start_index:end_index],
+            target_format="xy",
+            rows=image.height,
+            cols=image.width,
+        )
+        start_index = end_index
+
+        skeleton_fields.append(
+            Skeleton(
+                ref_field=[image.id],
+                instance_id=skeleton.instance_id,
+                label=skeleton.label,
+                keypoints=[
+                    Keypoint(
+                        ref_field=[image.id],
+                        instance_id=field.instance_id,
+                        label=field.label,
+                        x=x,
+                        y=y,
+                        name=field.name,
+                        index=field.index,
+                        annotated=field.annotated,
+                        occluded=(
+                            field.occluded
+                            or x < 0
+                            or image.width < x
+                            or y < 0
+                            or image.height < y
+                        ),
+                    )
+                    for (x, y), field in zip(keypoints, skeleton.keypoints)
+                ],
+                edges=skeleton.edges,
+            )
+        )
+
+    return skeleton_fields

--- a/efemarai/metamorph/domain.py
+++ b/efemarai/metamorph/domain.py
@@ -1,0 +1,265 @@
+from collections import Counter
+from random import choice, sample
+
+
+class Axis:
+    """An axis of data variability.
+
+    Attributes:
+        name: Name of the axis describing the semantic property it represents.
+        values: Sequence of all possible values along the axis.
+    """
+
+    def __init__(self, name, values):
+        self.name = name
+        self.values = values
+
+    def __len__(self):
+        return len(self.values)
+
+    @property
+    def min(self):
+        """Get the min value along the axis."""
+        return self.values[0]
+
+    @property
+    def max(self):
+        """Get the max value along the axis."""
+        return self.values[-1]
+
+    def sample(self, n=None):
+        """Get random value along the axis."""
+        if n is None:
+            return choice(self.values) if self.values else None
+
+        # Sample without replacement
+        if n <= len(self):
+            return sample(self.values, n)
+
+        # First sample without replacement, and then top up with replacement
+        try:
+            samples = self.sample(len(self))
+            samples += [self.sample() for _ in range(n - len(self))]
+        except Exception as e:
+            from monitoring import log
+
+            log.exception(
+                f"Getting an issue sampling axis: {self.name} - {self.values}. n: {n} axis len: {len(self)}"
+            )
+            raise e
+
+        return samples
+
+
+class Input:
+    def __init__(self, type, output_from, output_from_index):
+        self.type = type
+        self.output_from = output_from
+        self.output_from_index = output_from_index
+
+
+class Output:
+    def __init__(self, type, input_to):
+        self.type = type
+        self.input_to = input_to
+
+
+class Transformation:
+    """A parameterized data transformation.
+
+    Attributes:
+        operator: Function called with parameter values to construct the operator
+            that is to be applied to the data. The returned function should take a
+            dict with targets as input and return a dict with transformed targets.
+            A target may be an image, mask, masks, bboxes, keypoints, etc.
+        param_names: Sequence with the names of parameters used by the transform.
+    """
+
+    def __init__(self, id, operator, param_names, inputs, outputs):
+        assert isinstance(param_names, (tuple, list))
+        self.id = id
+        self.operator = operator
+        self.param_names = param_names
+        self.inputs = inputs
+        self.outputs = outputs
+
+    def __call__(self, params, *args):
+        """Construct the transform operator using params and apply it to the targets.
+
+        Args:
+            params: Dictionary mapping a parameter name to its value.
+            targets: Dictionary containing possible targets. Keys may include
+                "image", "mask", "masks", "bboxes", "keypoints" or any other target
+                supported by the transform operator.
+
+        Returns:
+            Dictionary with transformed targets.
+        """
+        assert all(name in params for name in self.param_names)
+
+        # TODO: Figure out if 'valid' needs to be dealt with here
+        # if not targets.get("valid", True):
+        #     return targets
+
+        param_values = tuple(params[name] for name in self.param_names)
+
+        return self.operator(*param_values)(*args)
+
+
+class Domain:
+    """Operational domain defining the search space.
+
+    A domain has a set of named axes that parameterize a set of transforms used
+    for searching. The domain can also be viewed as a single transform that is the
+    composition of all individual transforms.
+
+    Attributes:
+        axes: List of Axis objects.
+        transformations: List of individual transfroms per axis/axes.
+    """
+
+    def __init__(self):
+        self.axes = []
+        self.transformations = {}
+        self.sink = None
+
+    @property
+    def search_space(self):
+        """Get the search space defined by the domain.
+
+        Returns:
+            A dict mapping axis names to the possible axis values.
+        """
+        return {axis.name: list(axis.values) for axis in self.axes}
+
+    def add_transformation(self, id, operator, axes, inputs, outputs):
+        """Insert new axes of variability.
+
+        Args:
+            axes: Dict mapping axis name to an iterable with all possible values.
+            operator: Operator used by the transform.
+        """
+        self.transformations[id] = Transformation(
+            id=id,
+            operator=operator,
+            param_names=tuple(axes.keys()),
+            inputs=[
+                Input(
+                    type=input["type"],
+                    output_from=self.transformations[
+                        input["output_from"]["transformation"]
+                    ],
+                    output_from_index=input["output_from"]["index"],
+                )
+                for input in inputs
+            ],
+            outputs=[
+                Output(
+                    type=output["type"],
+                    input_to=output["input_to"],
+                )
+                for output in outputs
+            ],
+        )
+
+        if not outputs:
+            self.sink = self.transformations[id]
+
+        self.axes.extend([Axis(name, values) for name, values in axes.items()])
+
+    def get_transformation(self, sink=None):
+        """Get the overall transform the domain represents."""
+        if sink is None:
+            sink = self.sink
+
+        def transform(params, *args):
+            results = {}
+
+            # Avoid storing all intermediate results/outputs, so keep a reference
+            # count that is decreased every time the output is read. If the count
+            # reaches 0 then the intermediate result/output is deleted.
+            refs = Counter()
+
+            def apply(transformation):
+                inputs = []
+                for _input in transformation.inputs:
+                    output_from = _input.output_from
+                    if output_from.id not in results:
+                        results[output_from.id] = apply(output_from)
+                        for output in output_from.outputs:
+                            refs[output_from.id] += len(output.input_to)
+
+                    inputs.append(results[output_from.id][_input.output_from_index])
+                    refs[output_from.id] -= 1
+
+                    if refs[output_from.id] == 0:
+                        del results[output_from.id]
+                        del refs[output_from.id]
+
+                # At the beginning of the computation DAG
+                if not inputs:
+                    inputs = args
+
+                return transformation(params, *inputs)
+
+            return apply(sink)[0]
+
+        return transform
+
+    def sample(self, n=None):
+        """Get a random sample from the search space of the domain.
+
+        Returns:
+            A dict mapping axis names to sampled values.
+        """
+        axes_samples = {axis.name: axis.sample(n) for axis in self.axes}
+
+        if n is None:
+            return axes_samples
+
+        return [
+            {axis.name: axes_samples[axis.name][i] for axis in self.axes}
+            for i in range(n)
+        ]
+
+    def transform(self, *inputs, params=None):
+        """Apply the transform of the domain to a set of targets
+
+        Args:
+            params: Dict containing parameter values at which the transform to be evaluated.
+                If None a random sample will be generated.
+            targets: List with targets to be transformed.
+
+        Returns:
+            A dict with transformed targets.
+        """
+        transformation = self.get_transformation()
+
+        if params is not None:
+            return transformation(params, *inputs)
+
+        params = self.sample()
+        return transformation(params, *inputs), params
+
+    def generate(self, params=None):
+        """Generate a set new targets.
+
+        Often the search space will include an axis for choosing initial targets
+        that are to be transformed. In that case the synthesized targets can
+        be simply generated and not actually transformed.
+
+        Args:
+            params: Dict containing parameter values at which the transform to be
+                evaluated. If None a random sample will be generated.
+
+        Returns:
+            A Datapoint of the generated sample.
+        """
+        transformation = self.get_transformation()
+
+        if params is not None:
+            return transformation(params)
+
+        params = self.sample()
+
+        return transformation(params), params

--- a/efemarai/metamorph/domain_loader.py
+++ b/efemarai/metamorph/domain_loader.py
@@ -1,0 +1,120 @@
+import builtins
+from pydoc import locate
+
+import numpy as np
+
+from efemarai.metamorph.domain import Domain
+from efemarai.metamorph.operators_registry import METAMORPHS
+from efemarai.metamorph.vision.vision_metamorphs import ChooseImage
+
+
+class DomainLoader:
+    NUM_SAMPLES = 11
+
+    @staticmethod
+    def load(definition, dataset=None):
+        domain = Domain()
+        transformations = {
+            transformation["name"]: transformation
+            for transformation in definition["transformations"]
+        }
+
+        def traverse(transformation):
+            for input in transformation["inputs"]:
+                if input["output_from"] is None:
+                    return
+
+                traverse(transformations[input["output_from"]["transformation"]])
+
+            operator, free_params = DomainLoader._reify_transformation(transformation)
+
+            domain.add_transformation(
+                id=transformation["name"],
+                operator=operator,
+                axes=free_params,
+                inputs=transformation["inputs"],
+                outputs=transformation["outputs"],
+            )
+
+        evaluate_sample = next(
+            (
+                transformation
+                for transformation in transformations.values()
+                if not transformation["outputs"]
+            ),
+            None,
+        )
+
+        traverse(evaluate_sample)
+
+        return domain
+
+    @staticmethod
+    def _reify_transformation(transformation):
+        if not transformation["inputs"]:
+            return DomainLoader._reify_source(transformation)
+
+        operator = transformation["operator"]
+
+        free_params, fixed_params = DomainLoader._get_parameters(transformation)
+
+        def operator_with_free_params_only(*args):
+            kwargs = dict(zip(free_params.keys(), args))
+            kwargs.update(fixed_params)
+            return METAMORPHS[operator](**kwargs)
+
+        return operator_with_free_params_only, free_params
+
+    @staticmethod
+    def _reify_source(transformation):
+        if transformation["operator"] == "ChooseImage":
+            return (ChooseImage, {"image": [-1]})
+
+        raise ValueError("Transformation source cannot be established.")
+
+    @staticmethod
+    def _get_parameters(transformation):
+        free = {}
+        fixed = {}
+        for axis in transformation["axes"]:
+            try:
+                if axis["fixed"]:
+                    if axis["type"] in builtins.__dict__:
+                        fixed[axis["name"]] = locate(axis["type"])(axis["value"])
+                    else:
+                        constructor = locate("efemarai.metamorph." + axis["type"])
+                        fixed[axis["name"]] = constructor(*axis["value"])
+                else:
+                    free[axis["name"]] = DomainLoader._get_axis_values(axis)
+            except Exception as e:
+                print(
+                    f"Error for loading transformation '{axis.name}' "
+                    "with type '{axis.type}', value '{axis.value}'"
+                )
+                raise e
+        return free, fixed
+
+    @staticmethod
+    def _get_axis_values(axis):
+        if axis["type"] in ["float", "int"]:
+            if axis.get("range"):
+                low, high = axis["range"]
+                return np.unique(
+                    np.linspace(
+                        low, high, DomainLoader.NUM_SAMPLES, dtype=locate(axis["type"])
+                    )
+                ).tolist()
+
+            if axis.get("choices"):
+                return [locate(axis["type"])(choice) for choice in axis["choices"]]
+
+        if axis["type"] == "bool":
+            return [False, True]
+
+        if axis["type"] == "str":
+            return [str(choice) for choice in axis["choices"]]
+
+        raise ValueError(
+            f"Only 'float', 'int', 'bool', 'str' types are supported for now."
+            " Got {axis.type} for {axis.__dict__}"
+        )

--- a/efemarai/metamorph/loss/bounding_box_loss.py
+++ b/efemarai/metamorph/loss/bounding_box_loss.py
@@ -1,0 +1,239 @@
+from collections import defaultdict
+
+import numpy as np
+
+from efemarai.metamorph.loss.matching import greedy_entity_matching
+
+DEFAULT_BBOX_CONFIDENCE = 1.0
+
+
+def preprocess_bbox(targets, outputs):
+    gt_object, gt_class, pred_object, pred_class, pred_confidence = [], [], [], [], []
+
+    for target in targets:
+        target_obj = target.xyxy
+        target_cls = (
+            target.label.id
+            if hasattr(target, "label") and hasattr(target.label, "id")
+            else None
+        )
+        gt_object.append(target_obj)
+        gt_class.append(target_cls)
+
+    for output in outputs:
+        output_obj = output.xyxy
+        output_cls = (
+            output.label.id
+            if hasattr(output, "label") and hasattr(output.label, "id")
+            else None
+        )
+        output_conf = (
+            output.confidence
+            if not hasattr(output, "label") or not hasattr(output.label, "confidence")
+            else output.label.confidence
+        )
+        pred_object.append(output_obj)
+        pred_class.append(output_cls)
+        pred_confidence.append(
+            output_conf if output_conf is not None else DEFAULT_BBOX_CONFIDENCE
+        )
+
+    return (
+        np.array(gt_object),
+        np.array(gt_class),
+        np.array(pred_object),
+        np.array(pred_class),
+        np.array(pred_confidence),
+    )
+
+
+class BoxInfo:
+    """Holds all info about a bounding box.
+
+    Attributes:
+        box (np.ndarray): Array holding box coordinates (xmin, ymin, xmax, ymax).
+        label (int): Index of the box class.
+        confidence (Optional[float]): Confidence score of the bounding box.
+    """
+
+    def __init__(self, box, label, confidence=None):
+        self.box = box
+        self.label = label
+        self.confidence = confidence
+
+    def __repr__(self):
+        """Returns string  representation of the bounding box.
+
+        The format of the returned string is
+            "[(xmin, ymin), (xmax, ymax)], class-index, confidence"
+
+        where 'confidence' is included only if available.
+        """
+        xmin, ymin, xmax, ymax = [round(c) for c in self.box.tolist()]
+        res = "{"
+
+        res += f"({xmin}, {ymin}), ({xmax}, {ymax}), {int(self.label)}"
+
+        if self.confidence is not None:
+            res += f", {self.confidence:.4f}"
+
+        res += "}"
+
+        return res
+
+
+def box_iou(box1, box2):
+    """Computes the intersection over union of two set of boxes.
+
+    Each box needs to be represented as (xmin, ymin, xmax, ymax).
+
+    Args:
+        box1 (np.ndarray): bounding boxes, sized [N, 4].
+        box2 (np.ndarray): bounding boxes, sized [M, 4].
+
+    Return:
+        np.ndarray: iou, sized [N, M].
+
+    Reference:
+      https://github.com/chainer/chainercv/blob/master/chainercv/utils/bbox/bbox_iou.py
+      https://github.com/kuangliu/torchcv/blob/master/torchcv/utils/box.py
+    """
+    N = box1.shape[0]
+    M = box2.shape[0]
+
+    if N == 0 or M == 0:
+        return np.empty((N, M))
+
+    lt = np.maximum(box1[:, None, :2], box2[:, :2])  # [N,M,2]
+    rb = np.minimum(box1[:, None, 2:], box2[:, 2:])  # [N,M,2]
+
+    wh = (rb - lt).clip(min=0)  # [N,M,2]
+    inter = wh[:, :, 0] * wh[:, :, 1]  # [N,M]
+
+    area1 = (box1[:, 2] - box1[:, 0]) * (box1[:, 3] - box1[:, 1])  # [N,]
+    area2 = (box2[:, 2] - box2[:, 0]) * (box2[:, 3] - box2[:, 1])  # [M,]
+    iou = inter / (area1[:, None] + area2 - inter)
+
+    return iou
+
+
+def bounding_box_loss(
+    gt_boxes,
+    gt_classes,
+    pred_boxes,
+    pred_classes,
+    pred_confidence,
+    class_weights,
+    confusion_weights=None,
+):
+    """Calculates the failure score for a set of ground truth and prediction boxes.
+
+    The score is bounded in [0; 1] with 0 indicating that the predictions are good.
+
+    Args:
+        gt_boxes (np.array): Ground truth boxes with shape [Nx4]. Each box is
+            represented as (xmin, ymin, xmax, ymax).
+
+        gt_classes (np.array): Labels of the ground truth boxes with shape [N].
+
+        pred_boxes (np.array): Prediction boxes with shape [Mx4]. Each box is
+            represented as (xmin, ymin, xmax, ymax).
+
+        pred_classes (np.array): Labels of the prediction boxes with shape [N].
+
+        pred_confidence (np.array): Predictions confidence scores with shape [N].
+
+        class_weights (dict[int,float]): Dict mapping class id to class weight. Class weights are normalized such that sum of weights is 1.
+
+        confusion_weights (dict[int,tuple]): Dict mapping class id to confusion weights (tp, fp, fn). Confusion weights are normalized such that sum of weights is 1.
+
+
+    Returns:
+        A dict containing the failure score as well as score break down dicts showing
+        how individual boxes have been scored.
+    """
+    np.testing.assert_almost_equal(sum(class_weights.values()), 1)
+
+    if confusion_weights is None:
+        confusion_weights = defaultdict(lambda: (1 / 3, 1 / 3, 1 / 3))
+
+    # Ground Truth x Predictions
+    IoUs = box_iou(gt_boxes, pred_boxes)
+
+    # Ignore IoUs of boxes with different classes
+    IoUs[~np.equal.outer(gt_classes, pred_classes)] = 0
+
+    # Multiply each column with confidence score of respective prediction
+    IoUs *= pred_confidence
+
+    best_gt, best_pred, best_iou = greedy_entity_matching(IoUs)
+
+    gt_boxes_info = [BoxInfo(box, label) for box, label in zip(gt_boxes, gt_classes)]
+
+    pred_boxes_info = [
+        BoxInfo(box, label, confidence)
+        for box, label, confidence in zip(pred_boxes, pred_classes, pred_confidence)
+    ]
+
+    gt_scores = {
+        (box_info, repr(box_info)): (
+            best_iou[(i, best_pred[i])],
+            class_weights[box_info.label]
+            * confusion_weights[box_info.label][0],  # 0 -> tp
+        )
+        for i, box_info in enumerate(gt_boxes_info)
+        if i in best_pred
+    }
+
+    pred_scores = {
+        (box_info, repr(box_info)): (
+            best_iou[(best_gt[i], i)],
+            class_weights[box_info.label]
+            * confusion_weights[box_info.label][0],  # 0 -> tp
+        )
+        for i, box_info in enumerate(pred_boxes_info)
+        if i in best_gt
+    }
+
+    fp_scores = {
+        repr(box_info): (
+            -1.0 * confidence,
+            class_weights[box_info.label]
+            * confusion_weights[box_info.label][1],  # 1 -> fp
+        )
+        for i, (box_info, confidence) in enumerate(
+            zip(pred_boxes_info, pred_confidence)
+        )
+        if i not in best_gt
+    }
+
+    fn_scores = {
+        repr(box_info): (
+            -1.0,
+            class_weights[box_info.label]
+            * confusion_weights[box_info.label][2],  # 2 -> fn
+        )
+        for i, box_info in enumerate(gt_boxes_info)
+        if i not in best_pred
+    }
+
+    weighted_scores = []
+    weighted_scores += list(gt_scores.values())
+    weighted_scores += list(pred_scores.values())
+    weighted_scores += list(fp_scores.values())
+    weighted_scores += list(fn_scores.values())
+
+    loss = {
+        "pred_boxes_info": [repr(box_info) for box_info in pred_boxes_info],
+        "gt_boxes_info": [repr(box_info) for box_info in gt_boxes_info],
+        "gt_scores_info": {k[1]: v[0] for k, v in gt_scores.items()},
+        "pred_scores_info": {k[1]: v[0] for k, v in pred_scores.items()},
+        "fp_scores_info": {k[1]: v[0] for k, v in fp_scores.items()},
+        "fn_scores_info": {k[1]: v[0] for k, v in fn_scores.items()},
+        "failure_score_unnormalized": sum(
+            (1 - (s + 1) / 2) * w for (s, w) in weighted_scores
+        ),
+        "failure_score_normalization_constant": sum(w for (_, w) in weighted_scores),
+    }
+
+    return loss

--- a/efemarai/metamorph/loss/classification_loss.py
+++ b/efemarai/metamorph/loss/classification_loss.py
@@ -1,0 +1,77 @@
+import numpy as np
+
+
+def preprocess_tags(targets, outputs):
+    gt_class, pred_confidence = [], []
+
+    for target in targets:
+        target_cls = (
+            target.label.id
+            if hasattr(target, "label") and hasattr(target.label, "id")
+            else None
+        )
+        gt_class.append(target_cls)
+
+    for output in outputs:
+        if output.probabilities is not None:
+            probabilities = output.probabilities
+
+        pred_confidence.append(probabilities)
+
+    return (
+        np.array(gt_class),
+        np.array(pred_confidence),
+    )
+
+
+def one_hot_encode(ids, num_classes=None):
+    if isinstance(ids, list):
+        ids = np.asarray(ids)
+
+    if num_classes is None:
+        max_id = ids.max() + 1
+    else:
+        max_id = num_classes
+
+    one_hot = np.zeros((ids.size, max_id), dtype=int)
+    rows = np.arange(ids.size)
+    one_hot[rows, ids] = 1
+    return one_hot
+
+
+def classification_loss(gt_classes, pred_confidence, class_weights):
+
+    loss = {
+        "softmax_info": pred_confidence
+        if not hasattr(pred_confidence, "tolist")
+        else pred_confidence.tolist(),
+        "failure_score_normalization_constant": 1,
+    }
+    one_hot = one_hot_encode(gt_classes, num_classes=len(class_weights))
+
+    weights = np.zeros(len(class_weights))
+    for index, weight in class_weights.items():
+        weights[index] = weight
+
+    conf_diff = np.abs(one_hot - pred_confidence) * weights
+
+    loss["failure_score_unnormalized"] = conf_diff.sum().item()
+
+    return loss
+
+
+def cross_entropy_loss(gt_classes, pred_confidence, class_weights):
+
+    loss = {
+        "softmax_info": pred_confidence
+        if not hasattr(pred_confidence, "tolist")
+        else pred_confidence.tolist(),
+        "failure_score_normalization_constant": 1,
+    }
+    one_hot = one_hot_encode(gt_classes, num_classes=len(class_weights))
+
+    cr_e = np.log(pred_confidence) * one_hot
+    cr_e = cr_e.sum().item() * -1
+    loss["failure_score_unnormalized"] = cr_e
+
+    return loss

--- a/efemarai/metamorph/loss/datapoint_loss.py
+++ b/efemarai/metamorph/loss/datapoint_loss.py
@@ -1,0 +1,226 @@
+from collections import defaultdict
+
+from efemarai import Datapoint
+from efemarai.metamorph.loss.bounding_box_loss import bounding_box_loss, preprocess_bbox
+from efemarai.metamorph.loss.classification_loss import (
+    classification_loss,
+    preprocess_tags,
+)
+from efemarai.metamorph.loss.instance_segmentation_loss import (
+    mask_loss,
+    preprocess_polygon,
+)
+from efemarai.metamorph.loss.keypoint_loss import (
+    keypoint_loss,
+    preprocess_keypoints,
+    preprocess_skeleton,
+)
+from efemarai.metamorph.loss.regression_loss import regression_loss
+from efemarai.metamorph.loss.text_loss import preprocess_text, text_loss
+
+INSTANCE_PREPROCESSORS = {
+    "Polygon": preprocess_polygon,
+    "BoundingBox": preprocess_bbox,
+    "Keypoint": preprocess_keypoints,
+    "Skeleton": preprocess_skeleton,
+}
+INSTANCE_LOSSES = {
+    "Polygon": mask_loss,
+    "BoundingBox": bounding_box_loss,
+    "Keypoint": keypoint_loss,
+    "Skeleton": keypoint_loss,
+}
+
+
+def load_mask(fields):
+    base_fields = fields.targets if isinstance(fields, Datapoint) else fields.outputs
+    for target in base_fields:
+
+        if target._cls == "Polygon":
+            inputs = (
+                fields.inputs if isinstance(fields, Datapoint) else fields.inputs.inputs
+            )
+            ref_inputs = list(
+                filter(
+                    lambda _input: _input.id in target.ref_field
+                    and _input._cls == "Image",
+                    inputs,
+                )
+            )
+            for ref_input in ref_inputs:
+                target.load_raw_data(ref_input.width, ref_input.height)
+
+        # TODO Handle masks
+        if "Mask" in target._cls:
+            print("Loading mask: ", target.data.shape)
+
+
+def group_fields_by_type(fields):
+    """
+    Args:
+        fields (dict): orm.models.Datapoint or orm.models.ModelOutput.
+
+        key (str): Dict key corresponding to the objects datapoints and model_outputs.
+
+    Return:
+        fields grouped by type (dict(ef.field : dict(ref_field:[ef.BaseField]))):
+    """
+    fields_grouped_by_type = defaultdict(lambda: defaultdict(list))
+
+    for field in fields:
+        field.ref_field.sort()
+        # Loss is not calculated if "require_loss" is added as False in the user_attributes.
+        if field._requires_loss:
+            fields_grouped_by_type[field._cls][str(field.ref_field)].append(field)
+    return fields_grouped_by_type
+
+
+def update_loss_dict(source_dict, target_dict, weight=1):
+    for key in source_dict.keys():
+        if key not in target_dict:
+            target_dict.update({key: source_dict[key]})
+
+        if isinstance(target_dict[key], (dict, list)):
+            target_dict[key].extend(source_dict[key])
+
+        else:
+            target_dict[key] += (
+                source_dict[key] * weight
+                if "failure_score" in key
+                else source_dict[key]
+            )
+
+    return target_dict
+
+
+def datapoint_loss(
+    datapoint, model_output, class_weights, field_weights, confusion_weights=None
+):
+
+    if confusion_weights is None:
+        confusion_weights = defaultdict(lambda: (1 / 3, 1 / 3, 1 / 3))
+
+    loss = {
+        "pred_instances_info": [],
+        "gt_instance_info": [],
+        "gt_scores_info": [],
+        "pred_scores_info": [],
+        "fp_scores_info": [],
+        "fn_scores_info": [],
+        "failure_score_unnormalized": 0,
+        "failure_score_normalization_constant": 0,
+    }
+
+    load_mask(datapoint)
+    load_mask(model_output)
+
+    grouped_target_fields = group_fields_by_type(datapoint.targets)
+    grouped_output_fields = group_fields_by_type(model_output.outputs)
+
+    field_types = set(
+        list(grouped_target_fields.keys()) + list(grouped_output_fields.keys())
+    )
+
+    # No gt and no pred.
+    if not field_types:
+        loss["failure_score_normalization_constant"] = 1
+        return loss
+
+    # No target but prediciton or no prediction but target
+    if (not grouped_target_fields and grouped_output_fields) or (
+        grouped_target_fields and not grouped_output_fields
+    ):
+        loss["failure_score_unnormalized"] += 1
+        loss["failure_score_normalization_constant"] += 1
+        return loss
+
+    # TODO: Instantiate the metric only once before reaching the loss calculation.
+    if "Text" in field_types:
+        from torchmetrics.text.bert import BERTScore
+
+        # Single process for the dataloader inside the master process. Required because we use mp.Pool
+        bertscore = BERTScore(num_threads=0, verbose=True)
+
+    # TODO: filter for field.user_attributes.get("loss") == False
+    for field_type in field_types:
+        loss_type_weight = field_weights[field_type]
+        field_loss = {
+            "pred_instances_info": [],
+            "gt_instance_info": [],
+            "gt_scores_info": [],
+            "pred_scores_info": [],
+            "fp_scores_info": [],
+            "fn_scores_info": [],
+            "failure_score_unnormalized": 0,
+            "failure_score_normalization_constant": 0,
+        }
+        for target_ref in grouped_target_fields[field_type]:
+
+            # TODO: Think of a better way to handle this case. Is that the case?
+            if target_ref not in grouped_output_fields[field_type]:
+                field_loss["failure_score_unnormalized"] += 1
+                field_loss["failure_score_normalization_constant"] += 1
+                continue
+
+            # Object Detection, Instance Segmentation, Keypoints
+            if field_type in ["BoundingBox", "Polygon", "Keypoint", "Skeleton"]:
+                (
+                    gt_instances,
+                    gt_classes,
+                    pred_instances,
+                    pred_classes,
+                    pred_confidence,
+                ) = INSTANCE_PREPROCESSORS[field_type](
+                    grouped_target_fields[field_type][target_ref],
+                    grouped_output_fields[field_type][target_ref],
+                )
+
+                tmp_loss = INSTANCE_LOSSES[field_type](
+                    gt_instances,
+                    gt_classes,
+                    pred_instances,
+                    pred_classes,
+                    pred_confidence,
+                    class_weights,
+                    confusion_weights,
+                )
+
+            # TODO: Add class weights
+            # Regression
+            elif field_type == "Value":
+                tmp_loss = regression_loss(
+                    grouped_target_fields[field_type][target_ref],
+                    grouped_output_fields[field_type][target_ref],
+                )
+
+            # Classification
+            elif field_type == "Tag":
+                gt_classes, pred_confidence = preprocess_tags(
+                    grouped_target_fields[field_type][target_ref],
+                    grouped_output_fields[field_type][target_ref],
+                )
+                tmp_loss = classification_loss(
+                    gt_classes, pred_confidence, class_weights
+                )
+
+            # Text
+            elif field_type == "Text":
+                gt_classes, pred_confidence = preprocess_text(
+                    grouped_target_fields[field_type][target_ref],
+                    grouped_output_fields[field_type][target_ref],
+                )
+                tmp_loss = text_loss(
+                    metric=bertscore, targets=gt_classes, preds=pred_confidence
+                )
+
+            else:
+                # TODO  compute loss for other fields
+                print(f"Loss not implemented for field_type '{field_type}'.")
+                tmp_loss = {
+                    "failure_score_unnormalized": 0,
+                    "failure_score_normalization_constant": 1,
+                }
+
+            field_loss = update_loss_dict(tmp_loss, field_loss)
+        loss = update_loss_dict(field_loss, loss, weight=loss_type_weight)
+    return loss

--- a/efemarai/metamorph/loss/instance_segmentation_loss.py
+++ b/efemarai/metamorph/loss/instance_segmentation_loss.py
@@ -1,0 +1,217 @@
+from collections import defaultdict
+
+import numpy as np
+
+from efemarai.metamorph.loss.matching import greedy_entity_matching
+
+DEFAULT_SEGM_CONFIDENCE = 1.0
+
+
+def preprocess_polygon(targets, outputs):
+    gt_object, gt_class, pred_object, pred_class, pred_confidence = [], [], [], [], []
+
+    for target in targets:
+        target_obj = target._raw_data
+        target_cls = (
+            target.label.id
+            if hasattr(target, "label") and hasattr(target.label, "id")
+            else None
+        )
+        gt_object.append(target_obj)
+        gt_class.append(target_cls)
+
+    for output in outputs:
+        output_obj = output._raw_data
+        output_cls = (
+            output.label.id
+            if hasattr(output, "label") and hasattr(output.label, "id")
+            else None
+        )
+        output_conf = (
+            output.confidence
+            if not hasattr(output, "label") or not hasattr(output.label, "confidence")
+            else output.label.confidence
+        )
+        pred_object.append(output_obj)
+        pred_class.append(output_cls)
+        pred_confidence.append(
+            output_conf if output_conf is not None else DEFAULT_SEGM_CONFIDENCE
+        )
+
+    return (
+        np.array(gt_object),
+        np.array(gt_class),
+        np.array(pred_object),
+        np.array(pred_class),
+        np.array(pred_confidence),
+    )
+
+
+class MaskInfo:
+    """Holds all info about a mask.
+
+    Attributes:
+        mask (np.ndarray): Array holding mask information (mask).
+        label (int): Index of the mask class.
+        confidence (Optional[float]): Confidence score of the mask.
+    """
+
+    def __init__(self, mask, label, confidence=None):
+        self.mask = mask
+        self.label = label
+        self.confidence = confidence
+
+    def __repr__(self):
+        """Returns string representation of the bounding box inscribing the mask.
+
+        The format of the returned string is
+            "[x1, y1, x2, y2], class-index, confidence"
+
+        where 'confidence' is included only if available.
+        """
+        # TODO: Add option to return string representation of the polygons
+        coords = np.argwhere(np.asarray(self.mask))
+
+        res = "{"
+
+        if coords.sum() > 0:
+            top, left = coords.min(axis=0)
+            bottom, right = coords.max(axis=0)
+            res += f"({top} {left} {bottom} {right}), {int(self.label)}"
+
+        else:
+            res += f"(0 0 0 0), {int(self.label)}"
+
+        if self.confidence is not None:
+            res += f", {self.confidence:.4f}"
+
+        res += "}"
+
+        return res
+
+
+def mask_loss(
+    gt_masks,
+    gt_classes,
+    pred_masks,
+    pred_classes,
+    pred_confidence,
+    class_weights,
+    confusion_weights=None,
+):
+    """Calculates the failure score for a set of ground truth and prediction masks.
+
+    The score is bounded in [0; 1] with 0 indicating that the predictions are good.
+
+    Args:
+        gt_masks (np.array): Ground truth PIL Image with shape [NxM] when loaded where N and M are the width and height of the mask.
+
+        gt_classes (np.array): Labels of the ground truth PIL Image with shape [K] when loaded.
+
+        pred_masks (np.array): Prediction PIL Image with shape [NxM] when loaded where N and M are the width and height of the mask.
+
+        pred_classes (np.array): Labels of the prediction PIL Image with shape [N] when loaded.
+
+        pred_confidence (np.array): Predictions confidence scores with shape [N].
+
+        class_weights (dict[int,float]): Dict mapping class id to class weight. Class weights are normalized such that sum of weights is 1.
+
+        confusion_weights (dict[int,tuple]): Dict mapping class id to confusion weights (tp, fp, fn). Confusion weights are normalized such that sum of weights is 1.
+
+    Returns:
+        A dict containing the failure score as well as score break down dicts showing
+        how individual masks have been scored.
+    """
+    np.testing.assert_almost_equal(sum(class_weights.values()), 1)
+
+    if confusion_weights is None:
+        confusion_weights = defaultdict(lambda: (1 / 3, 1 / 3, 1 / 3))
+
+    from pycocotools import mask as cocomask
+
+    threshold = 0.5
+
+    gt_m = [cocomask.encode(np.asfortranarray(m > threshold)) for m in gt_masks]
+    pred_m = [cocomask.encode(np.asfortranarray(m > threshold)) for m in pred_masks]
+
+    if len(gt_masks) == 0 or len(pred_masks) == 0:
+        pairwise_iou = np.zeros((len(gt_masks), len(pred_masks)))
+
+    else:
+        pairwise_iou = np.asarray(cocomask.iou(gt_m, pred_m, [0] * len(pred_m)))
+        # Ignore IoUs of polygons with different classes
+        pairwise_iou[~np.equal.outer(gt_classes, pred_classes)] = 0
+
+    # Multiply each column with confidence score of respective prediction
+    pairwise_iou *= pred_confidence
+
+    best_gt, best_pred, best_iou = greedy_entity_matching(pairwise_iou)
+
+    gt_masks_info = [MaskInfo(mask, label) for mask, label in zip(gt_masks, gt_classes)]
+
+    pred_masks_info = [
+        MaskInfo(mask, label, confidence)
+        for mask, label, confidence in zip(pred_masks, pred_classes, pred_confidence)
+    ]
+
+    gt_scores = {
+        (polygon_info, repr(polygon_info)): (
+            best_iou[(i, best_pred[i])],
+            class_weights[polygon_info.label]
+            * confusion_weights[polygon_info.label][0],  # 0 -> tp
+        )
+        for i, polygon_info in enumerate(gt_masks_info)
+        if i in best_pred
+    }
+
+    pred_scores = {
+        (polygon_info, repr(polygon_info)): (
+            best_iou[(best_gt[i], i)],
+            class_weights[polygon_info.label]
+            * confusion_weights[polygon_info.label][0],  # 0 -> tp
+        )
+        for i, polygon_info in enumerate(pred_masks_info)
+        if i in best_gt
+    }
+
+    fp_scores = {
+        repr(polygon_info): (
+            -1.0 * confidence,
+            class_weights[polygon_info.label]
+            * confusion_weights[polygon_info.label][1],  # 1 -> fp
+        )
+        for i, (polygon_info, confidence) in enumerate(
+            zip(pred_masks_info, pred_confidence)
+        )
+        if i not in best_gt
+    }
+
+    fn_scores = {
+        repr(polygon_info): (
+            -1.0,
+            class_weights[polygon_info.label]
+            * confusion_weights[polygon_info.label][2],  # 2 -> fn
+        )
+        for i, polygon_info in enumerate(gt_masks_info)
+        if i not in best_pred
+    }
+
+    weighted_scores = []
+    weighted_scores += list(gt_scores.values())
+    weighted_scores += list(pred_scores.values())
+    weighted_scores += list(fp_scores.values())
+    weighted_scores += list(fn_scores.values())
+
+    loss = {
+        "pred_masks_info": [repr(polygon_info) for polygon_info in pred_masks_info],
+        "gt_masks_info": [repr(polygon_info) for polygon_info in gt_masks_info],
+        "gt_scores_info": {k[1]: v[0] for k, v in gt_scores.items()},
+        "pred_scores_info": {k[1]: v[0] for k, v in pred_scores.items()},
+        "fp_scores_info": {k[1]: v[0] for k, v in fp_scores.items()},
+        "fn_scores_info": {k[1]: v[0] for k, v in fn_scores.items()},
+        "failure_score_unnormalized": sum(
+            (1 - (s + 1) / 2) * w for (s, w) in weighted_scores
+        ),
+        "failure_score_normalization_constant": sum(w for (_, w) in weighted_scores),
+    }
+    return loss

--- a/efemarai/metamorph/loss/keypoint_loss.py
+++ b/efemarai/metamorph/loss/keypoint_loss.py
@@ -1,0 +1,318 @@
+from collections import defaultdict
+
+import numpy as np
+
+from efemarai.metamorph.loss.matching import (
+    calculate_pairwise_distances,
+    greedy_entity_matching,
+)
+
+DEFAULT_KEYPOINT_CONFIDENCE = 1.0
+DEFAULT_SKELETON_CONFIDENCE = 1.0
+
+
+def preprocess_keypoints(targets, outputs):
+    """
+    Extract the needed data from ef.Field objects.
+    Args:
+        targets (dict): Ground truth serialized ef.BaseFields
+
+        outputs (dict): Predicted serialized ef.BaseFields
+    Return:
+        gt_instances (np.array): Ground truth instances.
+
+        gt_classes (np.array): Labels of the ground truth instances with shape [K].
+
+        pred_instances (np.array): Prediction instances.
+
+        pred_classes (np.array): Labels of the prediction instances with shape [N].
+
+        pred_confidence (np.array): Predictions confidence scores with shape [N].
+
+    """
+    gt_object, pred_object, pred_confidence = [], [], []
+    target_ids = {target.instance_id for target in targets}
+    for skeleton_id in target_ids:
+        gt_object.append(
+            [
+                (target.x, target.y, float(target.occluded))
+                for target in targets
+                if target.instance_id == skeleton_id
+            ]
+        )
+
+    output_ids = {output.instance_id for output in outputs}
+    for skeleton_id in output_ids:
+        pred_object.append(
+            [
+                (output.x, output.y, float(output.occluded))
+                for output in outputs
+                if output.instance_id == skeleton_id
+            ]
+        )
+        # TODO: Think of how to aggregate the keypoint score per group
+        pred_confidence.append(
+            # np.array(
+            #     [
+            #         (
+            #             output.confidence
+            #             if not hasattr(output, "label")
+            #             or not hasattr(output.label, "confidence")
+            #             else output.label.confidence
+            #         )
+            #         for output in outputs
+            #         if output.instance_id == skeleton_id
+            #     ]
+            # ).mean()
+            # np.random.rand()
+            DEFAULT_KEYPOINT_CONFIDENCE
+        )
+
+    return (
+        np.array(gt_object),
+        np.array(list(target_ids)),
+        np.array(pred_object),
+        np.array(list(output_ids)),
+        np.array(pred_confidence),
+    )
+
+
+def preprocess_skeleton(targets, outputs):
+    """
+    Extract the needed data from ef.Field objects.
+    Args:
+        targets (dict): Ground truth serialized ef.BaseFields
+
+        outputs (dict): Predicted serialized ef.BaseFields
+    Return:
+        gt_instances (np.array): Ground truth instances.
+
+        gt_classes (np.array): Labels of the ground truth instances with shape [K].
+
+        pred_instances (np.array): Prediction instances.
+
+        pred_classes (np.array): Labels of the prediction instances with shape [N].
+
+        pred_confidence (np.array): Predictions confidence scores with shape [N].
+
+    """
+    gt_object, pred_object, pred_confidence = [], [], []
+    target_ids = {target.instance_id for target in targets}
+    for skeleton in targets:
+        gt_object.append(
+            [
+                (keypoint_field.x, keypoint_field.y, float(keypoint_field.occluded))
+                for keypoint_field in skeleton.keypoints
+                if keypoint_field.instance_id == skeleton.instance_id
+            ]
+        )
+
+    output_ids = {output.instance_id for output in outputs}
+    for skeleton in outputs:
+        pred_object.append(
+            [
+                (keypoint_field.x, keypoint_field.y, float(keypoint_field.occluded))
+                for keypoint_field in skeleton.keypoints
+                if keypoint_field.instance_id == skeleton.instance_id
+            ]
+        )
+        # TODO: Think of how to aggregate the keypoint score per group
+        pred_confidence.append(DEFAULT_SKELETON_CONFIDENCE)
+
+    return (
+        np.array(gt_object),
+        np.array(list(target_ids)),
+        np.array(pred_object),
+        np.array(list(output_ids)),
+        np.array(pred_confidence),
+    )
+
+
+class KeypointInfo:
+    """Holds all info about a keypoint.
+
+    Attributes:
+        keypoint (np.ndarray): Array holding keypoint information (keypoint).
+        label (int): Index of the keypoint class.
+        confidence (Optional[float]): Confidence score of the keypoint.
+    """
+
+    def __init__(self, keypoint, label, confidence=None):
+        self.keypoint = keypoint
+        self.label = label
+        self.confidence = confidence
+
+    def __repr__(self):
+        """Returns string representation of the bounding box inscribing the keypoint.
+
+        The format of the returned string is
+            "[x, y, (z)], class-index, confidence"
+
+        where 'confidence' is included only if available.
+        """
+        res = "{"
+        res += f"({self.keypoint}"
+        res += f") {int(self.label)}"
+
+        if self.confidence is not None:
+            res += f", {self.confidence:.4f}"
+
+        res += "}"
+
+        return res
+
+
+def scale_coords_to_zero_one(keypoints, image_size):
+    if keypoints.ndim == 3 and (
+        keypoints[:, :, 0].max() > 1 or keypoints[:, :, 1].max() > 1
+    ):
+        keypoints[:, :, 0] /= image_size[0]
+        keypoints[:, :, 1] /= image_size[1]
+    return keypoints
+
+
+def filter_empty_groups(keypoints):
+    """Returns the keypoints with filtered out zero groups.
+
+    A zero group is a group which consists of only [0,0,0] elements.
+
+    Args:
+        keypoints (np.array): Keypoints with shape [n_groups, n_elements, N] where
+    N == 3 when the image is 2d [x, y, visibility]
+    N == 4 when the image is 3d [x, y, z, visibility]
+
+    Returns:
+        A numpy ndarray with filtered out empty groups.
+
+    """
+    return keypoints[np.unique(keypoints.nonzero()[0])]
+
+
+def keypoint_loss(
+    gt_keypoints,
+    gt_classes,
+    pred_keypoints,
+    pred_classes,
+    pred_confidence,
+    class_weights,
+    confusion_weights=None,
+):
+    """Calculates the failure score for a set of ground truth and prediction keypoints.
+
+    The score is bounded in [0; 1] with 0 indicating that the predictions are good.
+
+    Args:
+        gt_keypoints (np.array): Ground truth keypoints with shape [NxMxP] where N and M are the groups and keypoints in group.
+    P can be either 3 or 4, for 2d images and 3d images respectively. P is [x, y, (z), visibility].
+
+        gt_classes (np.array): Labels of the ground truth keypoints groups with shape [K].
+
+        pred_keypoints (np.array): Prediction keypoints with shape [NxMxP] where N and M are the groups and keypoints in group.
+    P can be either 3 or 4, for 2d images and 3d images respectively. P is [x, y, (z), confidence].
+
+        pred_classes (np.array): Labels of the prediction keypoint groups with shape [N].
+
+        pred_confidence (np.array): Predictions confidence scores with shape [N].
+
+        class_weights (dict[int,float]): Dict mapping class id to class weight. Class weights are normalized such that sum of weights is 1.
+
+        confusion_weights (dict[int,tuple]): Dict mapping class id to confusion weights (tp, fp, fn). Confusion weights are normalized such that sum of weights is 1.
+
+    Returns:
+        A dict containing the failure score as well as score break down dicts showing
+        how individual keypoints have been scored.
+    """
+    np.testing.assert_almost_equal(sum(class_weights.values()), 1)
+
+    gt_keypoints = filter_empty_groups(gt_keypoints)
+
+    if confusion_weights is None:
+        confusion_weights = defaultdict(lambda: (1 / 3, 1 / 3, 1 / 3))
+
+    # calculate pairwise distance between groups of keypoints
+    distances = calculate_pairwise_distances(gt_keypoints, pred_keypoints)
+
+    # use how close the groups are
+    closeness = 1 - distances
+
+    # Multiply each column with confidence score of respective prediction
+    closeness *= pred_confidence
+
+    best_gt, best_pred, best_closeness = greedy_entity_matching(closeness)
+
+    gt_keypoints_info = [
+        KeypointInfo(keypoint, label)
+        for keypoint, label in zip(gt_keypoints, gt_classes)
+    ]
+
+    pred_keypoints_info = [
+        KeypointInfo(keypoint, label, confidence=confidence)
+        for keypoint, label, confidence in zip(
+            pred_keypoints, pred_classes, pred_confidence
+        )
+    ]
+
+    gt_scores = {
+        (polygon_info, repr(polygon_info)): (
+            best_closeness[(i, best_pred[i])],
+            class_weights[polygon_info.label]
+            * confusion_weights[polygon_info.label][0],  # 0 -> tp
+        )
+        for i, polygon_info in enumerate(gt_keypoints_info)
+        if i in best_pred
+    }
+
+    pred_scores = {
+        (polygon_info, repr(polygon_info)): (
+            best_closeness[(best_gt[i], i)],
+            class_weights[polygon_info.label]
+            * confusion_weights[polygon_info.label][0],  # 0 -> tp
+        )
+        for i, polygon_info in enumerate(pred_keypoints_info)
+        if i in best_gt
+    }
+
+    fp_scores = {
+        repr(polygon_info): (
+            -1.0 * confidence,
+            class_weights[polygon_info.label]
+            * confusion_weights[polygon_info.label][1],  # 1 -> fp
+        )
+        for i, (polygon_info, confidence) in enumerate(
+            zip(pred_keypoints_info, pred_confidence)
+        )
+        if i not in best_gt
+    }
+
+    fn_scores = {
+        repr(polygon_info): (
+            -1.0,
+            class_weights[polygon_info.label]
+            * confusion_weights[polygon_info.label][2],  # 2 -> fn
+        )
+        for i, polygon_info in enumerate(gt_keypoints_info)
+        if i not in best_pred
+    }
+
+    weighted_scores = []
+    weighted_scores += list(gt_scores.values())
+    weighted_scores += list(pred_scores.values())
+    weighted_scores += list(fp_scores.values())
+    weighted_scores += list(fn_scores.values())
+
+    loss = {
+        "pred_keypoints_info": [
+            repr(polygon_info) for polygon_info in pred_keypoints_info
+        ],
+        "gt_keypoints_info": [repr(polygon_info) for polygon_info in gt_keypoints_info],
+        "gt_scores_info": {k[1]: v[0] for k, v in gt_scores.items()},
+        "pred_scores_info": {k[1]: v[0] for k, v in pred_scores.items()},
+        "fp_scores_info": {k[1]: v[0] for k, v in fp_scores.items()},
+        "fn_scores_info": {k[1]: v[0] for k, v in fn_scores.items()},
+        "failure_score_unnormalized": sum(
+            (1 - (s + 1) / 2) * w for (s, w) in weighted_scores
+        ),
+        "failure_score_normalization_constant": sum(w for (_, w) in weighted_scores),
+    }
+
+    return loss

--- a/efemarai/metamorph/loss/loss_functions.py
+++ b/efemarai/metamorph/loss/loss_functions.py
@@ -1,0 +1,86 @@
+# import numpy as np
+
+from efemarai.metamorph.loss.datapoint_loss import datapoint_loss
+
+# from efemarai.metamorph.loss.bounding_box_loss import bounding_box_loss
+# from efemarai.metamorph.loss.instance_segmentation_loss import mask_loss
+# from efemarai.metamorph.loss.keypoint_loss import (
+#     keypoint_loss,
+#     scale_coords_to_zero_one,
+# )
+
+# from orm import DatasetStore, ProblemType
+
+MASK_OUT_KEYS = ["area", "info"]
+
+
+def failure_loss(
+    datapoint, model_output, class_weights, field_weights, confusion_weights=None
+):
+    """
+    Loss function for custom problem type.
+    Args:
+        datapoint (ef.Datapoint): Datapoint object containting targets.
+
+        model_output (ef.ModelOutput): ModelOutput object containing predictions.
+
+        class_weights (dict[int,float]): Dict mapping class id to class weight. Class weights are normalized such that sum of weights is 1.
+
+        field_weights (dict[str
+        q,float]): Dict mapping ef.base_field._cls to weight. Field weights are normalized such that sum of weights is 1.
+
+        confusion_weights (dict[int,tuple]): Dict mapping class id to confusion weights (tp, fp, fn). Confusion weights are normalized such that sum of weights is 1.
+
+    Returns:
+        loss (dict): A dict containing the failure score as well as score break down dicts showing
+    """
+    return datapoint_loss(
+        datapoint,
+        model_output,
+        class_weights,
+        field_weights,
+        confusion_weights,
+    )
+
+
+def filter_loss(loss, mask_out_keys=None):
+    if mask_out_keys is None:
+        mask_out_keys = MASK_OUT_KEYS
+
+    return {
+        key: val
+        for key, val in loss.items()
+        if all(mask_key not in key for mask_key in mask_out_keys)
+    }
+
+
+def subtract_losses(loss_a, loss_b):
+    difference_loss = {}
+
+    for key in filter_loss(loss_a).keys():
+        if key.endswith("_normalization_constant"):
+            difference_loss[key] = max(loss_a[key], loss_b[key])
+        else:
+            difference_loss[key] = loss_a[key] - loss_b[key]
+
+    return difference_loss
+
+
+def normalize_loss(loss):
+    normalized_loss = {}
+    for key, value in loss.items():
+        if key.endswith("_normalization_constant"):
+            continue
+
+        if key.endswith("_unnormalized"):
+            key = key.replace("_unnormalized", "", 1)
+            denominator = loss[key + "_normalization_constant"]
+            value = value / denominator if denominator > 0 else 0
+
+        normalized_loss[key] = value
+
+    return normalized_loss
+
+
+def aggregate_loss(loss):
+    return sum(normalize_loss(filter_loss(loss)).values())

--- a/efemarai/metamorph/loss/matching.py
+++ b/efemarai/metamorph/loss/matching.py
@@ -1,0 +1,100 @@
+import math
+
+import numpy as np
+from scipy import spatial
+
+
+def greedy_entity_matching(IoUs):
+    """Matches predictions to ground truth classes in a greedy fashion.
+
+    Ground truth and prediction entities are matched together if they have
+    the largest IoU amongst all non-matched, but overlapping entities, and also
+    have the same class label. This is done iteratively until no other non-matched
+    overlapping pair of entities exists.
+
+    Args:
+        IoUs (np.ndarray): Pairwise IoUs between ground truth and prediction entities
+            with shape [number of ground truth entities, number of predicted entities].
+
+    Returns:
+        A tuple of (best_gt, best_pred, best_iou) which are dicts mapping
+        every matched prediction box index to the index of its ground truth box
+        (best_gt) and the other way round - each ground truth box index to its
+        prediction box index (best_pred). best_iou is a dict mapping a frozenset
+        of {gt_index, pred_index} to the IoU of these two matched entities.
+    """
+    # Avoid modifying input array
+    IoUs = IoUs.copy()
+
+    best_pred = {}
+    best_gt = {}
+    best_iou = {}
+
+    while IoUs.size > 0 and IoUs.max() > 0:
+        indices = np.where(IoUs == IoUs.max())
+
+        gt_index = indices[0][0]
+        pred_index = indices[1][0]
+
+        best_gt[pred_index] = gt_index
+        best_pred[gt_index] = pred_index
+
+        best_iou[(gt_index, pred_index)] = IoUs[gt_index, pred_index].item()
+        IoUs[gt_index] = 0
+        IoUs[:, pred_index] = 0
+
+    return best_gt, best_pred, best_iou
+
+
+def calculate_pairwise_distances(gt, pred):
+    """Matches ground truth keypoint group to prediction keypoint group based on minimal distance.
+
+    Computes distance between groups of keypoints based on pairwise distances computed between
+    keypoints inside groups. The final distances are represented as a mean of all distances inside the
+    group. The matched groups are the ones which have the least distance between them.
+
+    Args:
+        gt (np.ndarray): Ground truth keypoints with shape [number of keypoint groups,
+            number of keypoint vertices, 3], where the last dimension is [x, y, (z), v].
+            x & y & z (optional) are bound in [0, 1], v: 0-unlabeled, 1-invisible, 2-visible.
+        pred (np.ndarray): Prediction keypoints with shape [number of keypoint groups,
+            number of keypoint vertices, 3], where the last dimension is [x, y, (z), c].
+            x & y & z (optional) & c are bound in [0, 1].
+
+    Returns:
+        distances (np.ndarray): Pairwise distances between ground truth and prediction entities
+            with shape [number of ground truth entities, number of predicted entities].
+    """
+    distances = np.empty(shape=[gt.shape[0], pred.shape[0]], dtype=float)
+
+    for gt_group_idx, gt_group in enumerate(gt):
+        for pred_group_idx, pred_group in enumerate(pred):
+
+            group_distances = []
+
+            # For each GT keypoint, calculate the pairwise (idx to idx) distance to the PRED keypoint
+            for keypoint_gt, keypoint_pred in zip(gt_group, pred_group):
+
+                if keypoint_pred[-1] == 0:
+                    # If no prediction and GT is 0 -> correct
+                    if keypoint_gt[-1] == 0:
+                        group_distances.append(0)
+                        continue
+
+                # TODO: Export this as an option in the UI -> should the loss be calculated on hidden?
+                elif keypoint_gt[-1] == 2 or keypoint_gt[-1] == 1:
+                    # Calculate distance between visible and predicted
+                    group_distances.append(
+                        spatial.distance.euclidean(keypoint_gt[:-1], keypoint_pred[:-1])
+                        / math.sqrt(
+                            len(keypoint_gt[:-1])
+                        )  # normalize to a max distance of 1
+                    )
+                    continue
+
+                # Add max error for FP and FN.
+                group_distances.append(1)
+
+            distances[gt_group_idx, pred_group_idx] = np.array(group_distances).mean()
+
+    return distances

--- a/efemarai/metamorph/loss/regression_loss.py
+++ b/efemarai/metamorph/loss/regression_loss.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+
+def regression_loss(targets, preds):
+    from scipy import spatial
+
+    u = [ef_field.value for ef_field in targets]
+    v = [ef_field.value for ef_field in preds]
+
+    # TODO: Add class weights
+    dist = spatial.distance.euclidean(u, v)
+    norm = np.sqrt(len(u))
+
+    loss = {
+        "failure_score_unnormalized": dist,
+        "failure_score_normalization_constant": norm,
+    }
+    return loss

--- a/efemarai/metamorph/loss/text_loss.py
+++ b/efemarai/metamorph/loss/text_loss.py
@@ -1,0 +1,18 @@
+def preprocess_text(targets, outputs):
+    return (
+        [target.text for target in targets],
+        [output.text for output in outputs],
+    )
+
+
+def text_loss(metric, targets, preds):
+    # TODO: Take up all targets and preds. Option: ef.Text.text is a list of sentences
+    targets = [targets[0]]
+    score = metric(targets, preds)
+    # {"f1":float, "recall":float, "precision":float}
+    score = score["f1"] if isinstance(score["f1"], float) else score["f1"].mean()
+    loss = {
+        "failure_score_unnormalized": 1 - score,
+        "failure_score_normalization_constant": 1,
+    }
+    return loss

--- a/efemarai/metamorph/operators_registry.py
+++ b/efemarai/metamorph/operators_registry.py
@@ -1,0 +1,3 @@
+import efemarai.metamorph.vision.vision_metamorphs as vision
+
+METAMORPHS = vision.METAMORPHS

--- a/efemarai/metamorph/search_domain.py
+++ b/efemarai/metamorph/search_domain.py
@@ -1,0 +1,296 @@
+import functools
+import os
+from collections import defaultdict
+from contextlib import redirect_stderr, redirect_stdout
+
+import efemarai as ef
+import pandas as pd
+from efemarai.metamorph.loss.loss_functions import (
+    aggregate_loss,
+    failure_loss,
+    subtract_losses,
+)
+from hyperactive import Hyperactive
+from hyperactive.optimizers import RepulsingHillClimbingOptimizer
+from rich.progress import Progress, track
+
+
+def test_robustness(
+    dataset,
+    model,
+    domain,
+    dataset_format,
+    output_format,
+    input_format=None,
+    transform=None,
+    target_transform=None,
+    transforms=None,
+    hooks=None,
+    class_ids=None,
+    class_names=None,
+    dataset_index_to_id=None,
+    num_search_steps=100,
+):
+    """
+    Stress test a model and estimate its vulnerability w.r.t. an operational domain.
+
+    Args:
+        dataset: list[tuple]
+            List of (input, target) used for stress testing.
+
+        model: Callable
+            Model inference function mapping inputs to predictions.
+
+        domain: efemarai.metamorph.Domain
+            Operational domain specifying the allowed transformations and their ranges.
+            Use a predefined one in `efemarai.domains` or create a new one at `ci.efemarai.com`.
+
+        dataset_format: `efemarai.spec`
+            Specification of the dataset format. Standard dataset formats are listed
+            in `efemarai.formats`. For custom datasets, provide your own `efemarai.spec`
+            transforming dataset samples to `efemarai.Datapoint`.
+
+        output_format: `efemarai.spec`
+            Specification of the model input format. Standard input formats are listed
+            in `efemarai.formats`. For custom models, provide your own `efemarai.spec`
+            transforming a model output to a list of `efemarai.fields`.
+
+        input_format: `efemarai.spec`=None
+            Specification of the model input format. Standard input formats are listed
+            in `efemarai.formats`. For custom models, provide your own `efemarai.spec`
+            transforming an `efemarai.Datapoint` to a model input.
+
+        transform: Callable=None
+            User specified transformation applied to the inputs of a data sample.
+
+        target_transform: Callable=None
+            User specified transformation applied to the targets of a data sample.
+
+        transforms: Callable=None
+            User specified transformation applied both to the inputs and targets of a
+            data sample.
+
+        hooks: list[Callable]=None
+            A list of hooks called after every search step iteration as follows:
+                hook(
+                    original_datapoint: efemarai.Datapoint,
+                    transformed_datapoint: efemarai.Datapoint,
+                    model_output: List[efemarai.fields],
+                    original_datapoint_loss: dict,
+                    transformed_datapoint_loss: dict,
+                    vulnerability: float,
+                )
+
+        class_ids: list[int]=None
+            IDs of the classes in the dataset. If not provided this informatio will be extracted
+            from the dataset, but requires a pass over the entire dataset.
+
+        dataset_index_to_id: dict[int, int]=None
+            Optional dictionary mapping a dataset index to dataset sample id.
+
+        num_search_steps: int=100,
+            Number of iterations searching for failures within the operation domain.
+
+    Returns:
+
+        An `efemarai.RobsutnessTestReport` containing vulnerability per domain axis
+        as well as info about all searched elements of the operational domain.
+    """
+    if hooks is None:
+        hooks = []
+
+    if input_format is None:
+        input_format = ef.formats.DEFAULT_INPUT_FORMAT
+
+    if class_ids is None:
+        class_ids = _extract_class_ids(dataset, class_names)
+
+    class_weights = {class_id: 1 / len(class_ids) for class_id in class_ids}
+    field_weights = defaultdict(lambda: 1)
+    loss_fn = functools.partial(
+        failure_loss,
+        class_weights=class_weights,
+        field_weights=field_weights,
+    )
+
+    search_args = _get_search_args(
+        model=model,
+        domain=domain,
+        loss_fn=loss_fn,
+        transform=transform,
+        target_transform=target_transform,
+        transforms=transforms,
+        input_format=input_format,
+        output_format=output_format,
+        hooks=hooks,
+        num_search_steps=num_search_steps,
+    )
+
+    with Progress(transient=True) as progress:
+        task = progress.add_task("Testing", total=len(dataset))
+
+        samples = pd.DataFrame()
+        for index, (input, target) in enumerate(dataset):
+            datapoint = ef.Datapoint.create_from(dataset_format, (input, target))
+
+            if transform is not None:
+                input = transform(input)
+
+            if target_transform is not None:
+                target = target_transform(target)
+
+            if transforms is not None:
+                input, target = transforms(input, target)
+
+            output = model(input)
+
+            output = ef.ModelOutput.create_from(output_format, datapoint, output)
+
+            baseline_loss = loss_fn(datapoint, output)
+            baseline_score = aggregate_loss(baseline_loss)
+
+            search_args["baseline_datapoint"] = datapoint
+            search_args["baseline_loss"] = baseline_loss
+            search_args["baseline_score"] = baseline_score
+
+            new_samples = _execute_search(search_args)
+
+            if new_samples is not None:
+                new_samples.assign(
+                    image=index
+                    if dataset_index_to_id is None
+                    else dataset_index_to_id[index]
+                )
+                samples = pd.concat([samples, new_samples], ignore_index=True)
+
+            progress.update(task, advance=1)
+
+    report = ef.reports.RobustnessTestReport(samples)
+    report.print_vulnerability()
+
+    return report
+
+
+def _extract_class_ids(dataset, class_names):
+    if class_names is not None:
+        return list(range(len(class_names)))
+
+    class_ids = set()
+    class_names = set()
+    for _, target in track(
+        dataset,
+        description="Extracting classes info",
+        transient=True,
+    ):
+        targets = ef.Datapoint.create_targets_from(dataset_format[1], target)
+        labels = [target.label for target in targets if hasattr(target, "label")]
+        class_ids.update([label.id for label in labels if label.id is not None])
+        class_names.update([label.name for label in labels if label.name is not None])
+
+    return class_ids or list(range(class_names))
+
+
+def _get_search_args(
+    model,
+    domain,
+    loss_fn,
+    transform,
+    target_transform,
+    transforms,
+    input_format,
+    output_format,
+    hooks,
+    num_search_steps,
+    baseline_datapoint=None,
+    baseline_loss=None,
+    baseline_score=None,
+):
+    return {
+        "model": model,
+        "domain": domain,
+        "loss_fn": loss_fn,
+        "transform": transform,
+        "target_transform": target_transform,
+        "transforms": transforms,
+        "input_format": input_format,
+        "output_format": output_format,
+        "hooks": hooks,
+        "num_search_steps": num_search_steps,
+        "baseline_datapoint": baseline_datapoint,
+        "baseline_loss": baseline_loss,
+        "baseline_score": baseline_score,
+    }
+
+
+def _execute_search(args):
+    hyper = Hyperactive(verbosity=False)
+    hyper.add_search(
+        objective_function=_vulnerability_objective,
+        search_space=args["domain"].search_space,
+        n_iter=args["num_search_steps"],
+        optimizer=RepulsingHillClimbingOptimizer(),
+        initialize={"random": 3},
+        pass_through=args,
+    )
+
+    try:
+        hyper.run()
+    except Exception as e:
+        print(f"Stress testing failed: {e}")
+        return None
+
+    return hyper.search_data(_vulnerability_objective).drop_duplicates()
+
+
+def _vulnerability_objective(opt):
+    args = opt.pass_through
+
+    input_format = args["input_format"]
+    output_format = args["output_format"]
+
+    transform = args["transform"]
+    target_transform = args["target_transform"]
+    transforms = args["transforms"]
+
+    model = args["model"]
+    domain = opt.pass_through["domain"]
+    loss_fn = args["loss_fn"]
+    baseline_datapoint = opt.pass_through["baseline_datapoint"]
+    baseline_loss = args["baseline_loss"]
+
+    try:
+        datapoint = domain.transform(baseline_datapoint, params=opt.para_dict)
+    except Exception as e:
+        print(f"Transformation failed: {e}")
+        return float("nan")
+
+    input = ef.spec.convert(input_format, datapoint)
+
+    if transform is not None:
+        input = transform(input)
+
+    if target_transform is not None:
+        target = target_transform(target)
+
+    if transforms is not None:
+        input, target = transforms(input, target)
+
+    output = model(input)
+    output = ef.ModelOutput.create_from(output_format, datapoint, output)
+
+    sample_loss = loss_fn(datapoint, output)
+    sample_score = aggregate_loss(sample_loss)
+
+    vulnerability = aggregate_loss(subtract_losses(sample_loss, baseline_loss))
+
+    for hook in args["hooks"]:
+        hook(
+            baseline_datapoint,
+            datapoint,
+            output,
+            baseline_loss,
+            sample_loss,
+            vulnerability,
+        )
+
+    return vulnerability

--- a/efemarai/metamorph/vision/operators/custom_operators.py
+++ b/efemarai/metamorph/vision/operators/custom_operators.py
@@ -1,0 +1,76 @@
+import random
+from math import cos, pi, sin
+
+import albumentations as A
+import cv2
+import numpy as np
+from skimage.transform import PiecewiseAffineTransform
+
+
+class GenericNoOp:
+    """Creates a generic no operation that doesn't depend on any pre tf."""
+
+    def __call__(self, *args):
+        return args
+
+
+class MotionBlurDirectionLimit(A.Blur):
+    """Apply motion blur to the input image using a random-sized kernel.
+
+    Args:
+        blur_limit (int): maximum kernel size for blurring the input image.
+            Should be in range [3, inf). Default range: (3, 9).
+        direction (float): angle of the motion blur in degrees. Default: 0.
+        p (float): probability of applying the transform. Default: 0.5.
+
+    Targets:
+        image
+
+    Image types:
+        uint8, float32
+    """
+
+    def __init__(self, blur_limit=(3, 9), direction=0, always_apply=False, p=0.5):
+        super().__init__(blur_limit, always_apply, p)
+        self.direction = direction
+
+    @staticmethod
+    def apply(img, kernel=None, **params):
+        return A.functional.convolve(img, kernel=kernel)
+
+    def get_params(self):
+        ksize = random.choice(np.arange(self.blur_limit[0], self.blur_limit[1] + 1, 2))
+        if ksize <= 2:
+            raise ValueError(f"ksize must be > 2. Got: {ksize}")
+        kernel = np.zeros((ksize, ksize), dtype=np.uint8)
+
+        # Choose direction
+        angle = self.direction * pi / 180.0
+        b = cos(angle)
+        a = sin(angle)
+        x0, y0 = ksize // 2, ksize // 2
+        pt0 = (int(x0), int(y0))
+        pt1 = (int(x0 + a * 2 * ksize), int(y0 - b * 2 * ksize))
+        cv2.line(kernel, pt0, pt1, 1, thickness=1)
+
+        # Normalize kernel
+        kernel = kernel.astype(np.float32) / np.sum(kernel)
+        return {"kernel": kernel}
+
+
+class FastPiecewiseTransform(PiecewiseAffineTransform):
+    def __call__(self, coords):
+        coords = np.asarray(coords)
+
+        simplex = self._tesselation.find_simplex(coords)
+
+        affines = np.array(
+            [self.affines[i].params for i, _ in enumerate(self._tesselation.simplices)]
+        )[simplex]
+
+        pts = np.c_[coords, np.ones((coords.shape[0], 1))]
+
+        result = np.einsum("ij,ikj->ik", pts, affines)
+        result[simplex == -1, :] = -1
+
+        return result

--- a/efemarai/metamorph/vision/vision_metamorphs.py
+++ b/efemarai/metamorph/vision/vision_metamorphs.py
@@ -1,0 +1,1280 @@
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
+from typing import Generic, Optional, Tuple, Type, TypeVar
+
+import albumentations as A
+
+from efemarai.metamorph.adaptors import apply_albumentation, apply_paste
+from efemarai.metamorph.vision.operators.custom_operators import (
+    GenericNoOp,
+    MotionBlurDirectionLimit,
+)
+
+METAMORPHS = {}
+
+
+@dataclass
+class Box:
+    tx: float
+    ty: float
+    bx: float
+    by: float
+
+
+@dataclass
+class Color:
+    r: int
+    g: int
+    b: int
+
+
+T = TypeVar("T", bool, int, float, str, list, Color)
+
+
+@dataclass
+class OperatorParam(Generic[T]):
+    name: str
+    type: Type[T]
+    choices: Tuple[T]
+    range: Tuple[T]
+    ordered: bool
+    fixed: bool
+    value: Optional[T]
+    metadata_model: Optional[str]
+    tf_model: Optional[str]
+
+
+@dataclass
+class OperatorInput:
+    name: Optional[str]
+    type: str
+
+
+@dataclass
+class OperatorOutput:
+    name: Optional[str]
+    type: str
+
+
+class IOType(Enum):
+    Datapoint = "Datapoint"
+
+
+class Category(Enum):
+    Undefined = "Undefined"
+    Common = "Common"
+    Geometric = "Geometric"
+    Weather = "Weather"
+    Color = "Color"
+    Noise = "Noise"
+    FaceWorks = "FaceWorks"
+    MRI = "MRI"
+    Image = "Image"
+
+
+class Operator:
+    """Create a Operator that holds the information for the functions in this module."""
+
+    def __init__(self, operator):
+        self.operator = operator
+        self.name = self.operator.__name__
+        self.category = Category.Undefined
+        self.source = False
+        self.sink = False
+        self.merge = False
+        self.params = []
+        self.inputs = []
+        self.outputs = []
+
+    def add_param(
+        self,
+        name,
+        type,
+        choices,
+        range,
+        ordered,
+        fixed,
+        value,
+        metadata_model,
+        tf_model,
+    ):
+        self.params.append(
+            OperatorParam(
+                name,
+                type,
+                choices,
+                range,
+                ordered,
+                fixed,
+                value,
+                metadata_model,
+                tf_model,
+            )
+        )
+
+    def add_input(self, name, type):
+        self.inputs.append(OperatorInput(name, type.value))
+
+    def add_output(self, name, type):
+        self.outputs.append(OperatorOutput(name, type.value))
+
+    def __call__(self, *args, **kwargs):
+        return self.operator(*args, **kwargs)
+
+    def __repr__(self):
+        result = f"Operator: {self.operator} with params:"
+        for parameter in self.params:
+            result += "\n -"
+            result += f" name: {parameter.name:12}"
+            result += f" type: {parameter.type.__name__:5}"
+            result += f" range: {str(parameter.range):10}"
+            result += f" choices: {parameter.choices}"
+        return result
+
+
+def param(
+    name,
+    type,
+    choices=None,
+    range=None,
+    ordered=False,
+    fixed=False,
+    value=None,
+    metadata_model=None,
+    tf_model=None,
+):
+    """Register a function as a transformation."""
+
+    def decorator(func):
+        if func.__name__ not in METAMORPHS:
+            METAMORPHS[func.__name__] = Operator(func)
+
+        METAMORPHS[func.__name__].add_param(
+            name,
+            type,
+            choices,
+            range,
+            ordered,
+            fixed,
+            value,
+            metadata_model,
+            tf_model,
+        )
+
+        return func
+
+    return decorator
+
+
+def input(name=None, type=None):
+    if type is None:
+        type = IOType.Datapoint
+
+    def decorator(func):
+        if func.__name__ not in METAMORPHS:
+            METAMORPHS[func.__name__] = Operator(func)
+
+        METAMORPHS[func.__name__].add_input(name, type)
+
+        return func
+
+    return decorator
+
+
+def output(name=None, type=None):
+    if type is None:
+        type = IOType.Datapoint
+
+    def decorator(func):
+        if func.__name__ not in METAMORPHS:
+            METAMORPHS[func.__name__] = Operator(func)
+
+        METAMORPHS[func.__name__].add_output(name, type)
+
+        return func
+
+    return decorator
+
+
+def siso(input_name=None, input_type=None, output_name=None, output_type=None):
+    if input_type is None:
+        input_type = IOType.Datapoint
+
+    if output_type is None:
+        output_type = IOType.Datapoint
+
+    def decorator(func):
+        if func.__name__ not in METAMORPHS:
+            METAMORPHS[func.__name__] = Operator(func)
+
+        METAMORPHS[func.__name__].add_input(input_name, output_type)
+        METAMORPHS[func.__name__].add_output(output_name, output_type)
+
+        return func
+
+    return decorator
+
+
+def def_operator(category=None, source=False, sink=False, merge=False):
+    """Add further info to an operator."""
+
+    def decorator(func):
+        if func.__name__ not in METAMORPHS:
+            METAMORPHS[func.__name__] = Operator(func)
+
+        if category is not None:
+            METAMORPHS[func.__name__].category = category
+
+        METAMORPHS[func.__name__].source = source
+        METAMORPHS[func.__name__].sink = sink
+        METAMORPHS[func.__name__].merge = merge
+
+        # Stacked decorators are called in reverse order so fix by reversing again
+        METAMORPHS[func.__name__].params.reverse()
+        METAMORPHS[func.__name__].inputs.reverse()
+        METAMORPHS[func.__name__].outputs.reverse()
+
+        return func
+
+    return decorator
+
+
+@def_operator(category=Category.Noise)
+@param("blur", int, range=(0, 20))
+@siso()
+@apply_albumentation(filter_instances=False)
+def Blur(blur: int) -> Callable:
+    """Applies Gaussian Blur to an image.
+
+    Args:
+        blur (int): The strength of the blur operator. Should be >= 3 to be active.
+
+    Returns:
+        Callable: A function that applies the blur operator to a target named variable `image`.
+    """
+    if blur < 3:
+        return A.NoOp()
+
+    assert blur >= 3, "blur operator size should be greater than 3."
+
+    return A.Blur(blur_limit=(blur, blur), always_apply=True)
+
+
+@def_operator(category=Category.Noise)
+@param("median_blur_scale", int, range=(0, 15))
+@siso()
+@apply_albumentation(filter_instances=False)
+def MedianBlur(median_blur_scale: int) -> Callable:
+    """Applies Median Blur to an image.
+
+    Args:
+        median_blur_scale (int): The strength of the blur operator. blur = median_blur_scale * 2 + 1.
+
+    Returns:
+        Callable: A function that applies the median blur operator to a target named variable `image`.
+    """
+    if median_blur_scale == 0:
+        return A.NoOp()
+
+    assert (
+        median_blur_scale >= 1
+    ), "median_blur_scale operator size should be greater than 1."
+
+    median_blur = median_blur_scale * 2 + 1
+
+    return A.MedianBlur(blur_limit=(median_blur, median_blur), always_apply=True)
+
+
+@def_operator(category=Category.Color)
+@param("gamma", float, range=(0.5, 1.5))
+@siso()
+@apply_albumentation(filter_instances=False)
+def Gamma(gamma: float) -> Callable:
+    """Applies Gamma to an image.
+
+    Args:
+        gamma (float): The strength of the gamma operator.
+
+    Returns:
+        Callable: A function that applies the Gamma operator to a target named variable `image`.
+    """
+    assert gamma > 0, "gamma operator size should be greater than 0."
+
+    return A.RandomGamma(
+        gamma_limit=(int(gamma * 100), int(gamma * 100)), always_apply=True
+    )
+
+
+@def_operator(category=Category.Color)
+@param("brightness", float, range=(-0.5, 0.5))
+@param("contrast", float, range=(-0.5, 0.5))
+@siso()
+@apply_albumentation(filter_instances=False)
+def BrightnessContrast(brightness: float, contrast: float = 0) -> Callable:
+    """Applies Brightness and Contrast to an image.
+
+    Args:
+        brightness (float): The change in brightness.
+        contrast (float): The change in contrast.
+
+    Returns:
+        Callable: A function that adds brightness or contrast operator to a target named
+                  variable `image`.
+    """
+    return A.RandomBrightnessContrast(
+        brightness_limit=(brightness, brightness),
+        contrast_limit=(contrast, contrast),
+        always_apply=True,
+    )
+
+
+@def_operator(category=Category.Color)
+@param("intensity", float, range=(0, 1))
+@param("light_direction", float, range=(-180, 180))
+@siso()
+def LightFlood(intensity: float, light_direction: float) -> Callable:
+    """Applies Light Flood to an image.
+
+    Args:
+        intensity (float): Intensity of the incoming light.
+        light_direction (float): Direction of the source of the light.
+
+    Returns:
+        Callable: A function that adds brightness or contrast operator to a target named
+                  variable `image`.
+    """
+    return LightFloodOp(intensity=intensity, light_direction=light_direction)
+
+
+@def_operator(category=Category.Noise)
+@param("gauss_noise_var", float, range=(0, 10))
+@param("gauss_noise_mean", float, range=(-10, 10), fixed=True, value=0)
+@siso()
+@apply_albumentation(filter_instances=False)
+def GaussianNoise(gauss_noise_var: float, gauss_noise_mean: float = 0) -> Callable:
+    """Applies Gaussian Noise to an image.
+
+    Args:
+        gauss_noise_var (float): The variance of the Gaussian noise operator. Should be > 0.
+        gauss_noise_mean (float): The mean of the Gaussian noise operator.
+
+    Returns:
+        Callable: A function that applies the Gaussian noise operator to a target named variable `image`.
+    """
+    assert gauss_noise_var >= 0, "The gauss_noise_var should be > 0."
+
+    return A.GaussNoise(
+        var_limit=(gauss_noise_var, gauss_noise_var),
+        mean=gauss_noise_mean,
+        always_apply=True,
+    )
+
+
+@def_operator(category=Category.Color)
+@param("hue", int, range=(-100, 100))
+@param("sat", int, range=(-100, 100))
+@param("val", int, range=(-100, 100))
+@siso()
+@apply_albumentation(filter_instances=False)
+def ShiftHSV(hue: int, sat: int, val: int) -> Callable:
+    """Shift the hue, saturation and value of an image.
+
+    Args:
+        hue (int): Change the hue by this value.
+        sat (int): Change the saturation by this value.
+        val (int): Change the value by this value.
+
+    Returns:
+        Callable: A function that shifts the HSV of target named variable `image`.
+    """
+    return A.HueSaturationValue(
+        hue_shift_limit=(hue, hue),
+        sat_shift_limit=(sat, sat),
+        val_shift_limit=(val, val),
+        always_apply=True,
+    )
+
+
+@def_operator(category=Category.Noise)
+@param("motion_blur", int, range=(0, 20))
+@param("motion_direction", float, range=(0, 1))
+@siso()
+@apply_albumentation(filter_instances=False)
+def MotionBlur(motion_blur: int, motion_direction: float) -> Callable:
+    """Adds motion blur to an image.
+
+    Args:
+        motion_blur (int): The blur amount. Should be >= 3 to be active.
+        motion_direction (float): The direction of the motion. Should be in range [0..1].
+
+    Returns:
+        Callable: A function that adds motion blur to a target named variable `image`.
+    """
+    if motion_blur < 3:
+        return A.NoOp()
+
+    assert motion_blur >= 3, "motion_blur operator size should be greater than 3."
+    assert 0 <= motion_direction <= 1, "motion_direction should be in range [0..1]"
+
+    return MotionBlurDirectionLimit(
+        blur_limit=(motion_blur, motion_blur),
+        direction=motion_direction,
+        always_apply=True,
+    )
+
+
+# NB: There is a stocastic effect here.
+@def_operator(category=Category.Noise)
+@param("max_factor", float, range=(1, 2))
+@param("step_factor", float, range=(0, 0.05), fixed=True, value=0.025)
+@siso()
+@apply_albumentation(filter_instances=False)
+def ZoomBlur(max_factor: int, step_factor: float) -> Callable:
+    """Adds zoom blur to an image.
+
+    Args:
+        max_factor (float): Range for max factor for blurring
+        step_factor (float): Step parameter for np.arange
+
+    Returns:
+        Callable: A function that adds zoom blur to a target named variable `image`.
+    """
+    if max_factor <= 1 or step_factor < 0.01:
+        return A.NoOp()
+
+    return A.ZoomBlur(
+        max_factor=max_factor,
+        step_factor=step_factor,
+        always_apply=True,
+    )
+
+
+@def_operator(category=Category.Geometric)
+@param("hflip", bool, choices=(False, True))
+@siso()
+@apply_albumentation()
+def HorizontalFlip(hflip: bool) -> Callable:
+    """Applies Horizontal Flip to an image.
+
+    Args:
+        hflip (bool): Should the image be flipped.
+
+    Returns:
+        Callable: A function that applies the horizontal flip operator to a target named variable `image`.
+    """
+    return A.HorizontalFlip(p=0, always_apply=hflip)
+
+
+@def_operator(category=Category.Geometric)
+@param("vflip", bool, choices=(False, True))
+@siso()
+@apply_albumentation()
+def VerticalFlip(vflip: bool) -> Callable:
+    """Applies Vertical Flip to an image.
+
+    Args:
+        vflip (bool): Should the image be flipped.
+
+    Returns:
+        Callable: A function that applies the Vertical flip operator to a target named variable `image`.
+    """
+    return A.VerticalFlip(p=0, always_apply=vflip)
+
+
+@def_operator(category=Category.Geometric)
+@param("affine_scale", float, range=(0.75, 1.25))
+@param("shear_x", float, range=(-40, 40))
+@param("shear_y", float, range=(-40, 40))
+@param("affine_rotate", float, range=(-180, 180))
+@param("translate_x", float, range=(-0.5, 0.5), fixed=True, value=0)
+@param("translate_y", float, range=(-0.5, 0.5), fixed=True, value=0)
+@param("interpolation", int, choices=(0, 1, 2, 3, 4), fixed=True, value=1)
+@param("border_mode", int, choices=(0, 1, 2, 3, 4), fixed=True, value=1)
+@param("infill_color", Color, range=((0, 255),) * 3, fixed=True, value=(0,) * 3)
+@siso()
+@apply_albumentation()
+def Affine(
+    affine_scale: float,
+    translate_x: float = 0,
+    translate_y: float = 0,
+    affine_rotate: float = 0,
+    shear_x: float = 0,
+    shear_y: float = 0,
+    interpolation: int = 1,
+    border_mode: int = 1,
+    infill_color: Tuple[int, int, int] = (0, 0, 0),
+) -> Callable:
+    """Applies Affine transforms to an image.
+
+    Args:
+        affine_scale (float): Scale factor of the image, where 1.0 denotes "no change" and 0.5 is zoomed out to 50% of the original size.
+        translate_x (float): Translate image horizontally. 0 - no translation, 0.5 - translated by half the image.
+        translate_y (float): Translate image vertically. 0 - no translation, 0.5 - translated by half the image.
+        affine_rotate (float): Rotation in degrees around the centre of the image [-180..180].
+        shear_x (float): Shear image horizontally by that many degrees (Usually in [-40, 40]).
+        shear_y (float): Translate image vertically by that many degrees (Usually in [-40, 40]).
+        interpolation (int): Flag that is used to specify the interpolation algorithm. Should be one of:
+            cv2.INTER_LINEAR (default - 1), cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4, cv2.INTER_NEAREST.
+        border_mode (int): Flag that is used to specify the pixel extrapolation method. Should be one of:
+            cv2.BORDER_CONSTANT, cv2.BORDER_REPLICATE, cv2.BORDER_REFLECT, cv2.BORDER_WRAP, cv2.BORDER_REFLECT_101.
+        infill_color (int, int, int): The RGB color of the border created from the transformation.
+
+    Returns:
+        Callable: A function that applies Affine transforms to a target named variable `image`.
+    """
+    assert 0.5 <= affine_scale <= 1.5, "affine_scale should be in [0.5..1.5]."
+    assert -0.5 <= translate_x <= 0.5, "translate_x should be in [-0.5..0.5]."
+    assert -0.5 <= translate_y <= 0.5, "translate_y should be in [-0.5..0.5]."
+    assert -180 <= affine_rotate <= 180, "affine_rotate should be in [-180..180]."
+    assert -40 <= shear_x <= 40, "shear_x should be in [-40..40]."
+    assert -40 <= shear_y <= 40, "shear_y should be in [-40..40]."
+    assert interpolation in [0, 1, 2, 3, 4], "interpolation should be in [0..4]."
+    assert border_mode in [0, 1, 2, 3, 4], "border_mode should be in [0..4]."
+
+    if isinstance(infill_color, Color):
+        infill_color = [infill_color.r, infill_color.g, infill_color.b]
+
+    return A.Affine(
+        scale=affine_scale,
+        translate_percent={
+            "x": (translate_x, translate_x),
+            "y": (translate_y, translate_y),
+        },
+        rotate=(affine_rotate, affine_rotate),
+        shear={"x": (shear_x, shear_x), "y": (shear_y, shear_y)},
+        interpolation=interpolation,
+        mode=border_mode,
+        cval=infill_color,
+        always_apply=True,
+    )
+
+
+# NB: There is a stocastic effect here
+@def_operator(category=Category.Geometric)
+@param("elastic_alpha", float, range=(0.0, 80))
+@param("elastic_sigma", float, range=(-360, 360))
+@param("elastic_alpha_affine", float, range=(0, 1))
+@param("border_mode", int, choices=(0, 1, 2, 3, 4), fixed=True, value=0)
+@param("interpolation", int, choices=(0, 1, 2, 3, 4), fixed=True, value=1)
+@param("approximate", bool, choices=(True, False), fixed=True, value=True)
+@param("same_dxdy", bool, choices=(True, False), fixed=True, value=True)
+@siso()
+@apply_albumentation()
+def ElasticTransform(
+    elastic_alpha: float,
+    elastic_sigma: float = 0,
+    elastic_alpha_affine: float = 0,
+    interpolation: int = 1,
+    border_mode: int = 0,
+    approximate: bool = True,
+    same_dxdy: bool = True,
+) -> Callable:
+    """Applies Elastic transforms to an image.
+
+    Args:
+        elastic_alpha (float): Alpha factor.
+        elastic_sigma (float): Gaussian filter param.
+        elastic_alpha_affine (float): Alpha affine factor.
+        interpolation (int): Flag that is used to specify the interpolation algorithm. Should be one of:
+            cv2.INTER_LINEAR (default - 1), cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4, cv2.INTER_NEAREST.
+        border_mode (int): Flag that is used to specify the pixel extrapolation method. Should be one of:
+            cv2.BORDER_CONSTANT, cv2.BORDER_REPLICATE, cv2.BORDER_REFLECT, cv2.BORDER_WRAP, cv2.BORDER_REFLECT_101.
+        approximate (bool): Whether to smooth displacement map with fixed kernel size. Disabling this option gives ~2X slowdown on large images.
+        same_dxdy (bool): Whether to smooth displacement map with fixed kernel size. Disabling this option gives ~2X slowdown on large images.
+
+    Returns:
+        Callable: A function that applies Elastic transforms to a target named variable `image`.
+    """
+    assert 0 <= elastic_alpha <= 100, "elastic_alpha should be in [0.1..100]."
+    assert -360 <= elastic_sigma <= 360, "elastic_sigma should be in [-360..360]."
+    assert 0 <= elastic_alpha_affine <= 1, "elastic_alpha_affine should be in [0..1]."
+    assert interpolation in [0, 1, 2, 3, 4], "interpolation should be in [0..4]."
+    assert border_mode in [0, 1, 2, 3, 4], "border_mode should be in [0..4]."
+
+    if elastic_alpha < 0.1:
+        return A.NoOp()
+
+    return A.ElasticTransform(
+        alpha=elastic_alpha,
+        sigma=elastic_sigma,
+        alpha_affine=elastic_alpha_affine,
+        interpolation=interpolation,
+        border_mode=border_mode,
+        approximate=approximate,
+        same_dxdy=same_dxdy,
+        always_apply=True,
+    )
+
+
+@def_operator(category=Category.Geometric)
+@param("distort_limit", float, range=(-1, 1))
+@param("distort_shift_limit", float, range=(-10, 10))
+@param("border_mode", int, choices=(0, 1, 2, 3, 4), fixed=True, value=4)
+@param("interpolation", int, choices=(0, 1, 2, 3, 4), fixed=True, value=1)
+@siso()
+@apply_albumentation()
+def OpticalDistortion(
+    distort_limit: float,
+    distort_shift_limit: float = 0,
+    interpolation: int = 1,
+    border_mode: int = 4,
+) -> Callable:
+    """Applies OpticalDistortion transforms to an image.
+
+    Args:
+        distort_limit (float): Distortion factor
+        distort_shift_limit (float): Shift factor
+        interpolation (int): Flag that is used to specify the interpolation algorithm. Should be one of:
+            cv2.INTER_LINEAR (default - 1), cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4, cv2.INTER_NEAREST.
+        border_mode (int): Flag that is used to specify the pixel extrapolation method. Should be one of:
+            cv2.BORDER_CONSTANT, cv2.BORDER_REPLICATE, cv2.BORDER_REFLECT, cv2.BORDER_WRAP, cv2.BORDER_REFLECT_101.
+
+    Returns:
+        Callable: A function that applies Optical Distortion transforms to a target named variable `image`.
+    """
+    assert -1 <= distort_limit <= 1, "distort_limit should be in [-1..1]."
+    assert (
+        -10 <= distort_shift_limit <= 10
+    ), "distort_shift_limit should be in [-10..10]."
+    assert interpolation in [0, 1, 2, 3, 4], "interpolation should be in [0..4]."
+    assert border_mode in [0, 1, 2, 3, 4], "border_mode should be in [0..4]."
+
+    return A.OpticalDistortion(
+        distort_limit=(distort_limit, distort_limit),
+        shift_limit=(distort_shift_limit, distort_shift_limit),
+        interpolation=interpolation,
+        border_mode=border_mode,
+        always_apply=True,
+    )
+
+
+@def_operator(category=Category.Geometric)
+@param("num_steps", int, range=(0, 10))
+@param("distort_limit", float, range=(-0.3, 0.3))
+@param("border_mode", int, choices=(0, 1, 2, 3, 4), fixed=True, value=4)
+@param("border_color", Color, range=((0, 255),) * 3, fixed=True, value=(128,) * 3)
+@param("interpolation", int, choices=(0, 1, 2, 3, 4), fixed=True, value=1)
+@param("normalized", bool, choices=(False, True), fixed=True, value=False)
+@siso()
+@apply_albumentation()
+def GridDistortion(
+    num_steps: int,
+    distort_limit: float,
+    interpolation: int = 1,
+    border_color: int = 255,
+    border_mode: int = 4,
+    normalized: bool = False,
+) -> Callable:
+    """Applies GridDistortion transforms to an image.
+
+    Args:
+        num_steps (int): count of grid cells on each side
+        distort_limit (float): Distortion factor
+        interpolation (int): Flag that is used to specify the interpolation algorithm. Should be one of:
+            cv2.INTER_LINEAR (default - 1), cv2.INTER_CUBIC, cv2.INTER_AREA, cv2.INTER_LANCZOS4, cv2.INTER_NEAREST.
+        border_color (Color): The color of the border when cv2.BORDER_CONSTANT
+        border_mode (int): Flag that is used to specify the pixel extrapolation method. Should be one of:
+            cv2.BORDER_CONSTANT, cv2.BORDER_REPLICATE, cv2.BORDER_REFLECT, cv2.BORDER_WRAP, cv2.BORDER_REFLECT_101.
+        normalzied (bool): Distortion to be normalized to do not go outside the image
+
+    Returns:
+        Callable: A function that applies GridDistortion transforms to a target named variable `image`.
+    """
+    assert interpolation in [0, 1, 2, 3, 4], "interpolation should be in [0..4]."
+    assert border_mode in [0, 1, 2, 3, 4], "border_mode should be in [0..4]."
+
+    if num_steps == 0:
+        return A.NoOp()
+
+    if isinstance(border_color, Color):
+        border_color = [border_color.r, border_color.g, border_color.b]
+
+    return A.GridDistortion(
+        num_steps=num_steps,
+        distort_limit=(distort_limit, distort_limit),
+        interpolation=interpolation,
+        border_mode=border_mode,
+        normalized=normalized,
+        value=border_color,
+        always_apply=True,
+    )
+
+
+# NB: There is a stocastic effect here
+@def_operator(category=Category.Geometric)
+@param("perspective_scale", float, range=(0.0, 0.2))
+@param("border_mode", int, choices=(0, 1, 2, 3, 4), fixed=True, value=0)
+@siso()
+@apply_albumentation()
+def Perspective(
+    perspective_scale: float,
+    border_mode: int = 0,
+) -> Callable:
+    """Applies Perspective transforms to an image.
+
+    Args:
+        perspective_scale (float): Standard deviation of the normal distributions. These are used to sample the random distances of the subimage's corners from the full image's corners.
+        border_mode (int): Flag that is used to specify the pixel extrapolation method. Should be one of:
+            cv2.BORDER_CONSTANT, cv2.BORDER_REPLICATE, cv2.BORDER_REFLECT, cv2.BORDER_WRAP, cv2.BORDER_REFLECT_101.
+
+    Returns:
+        Callable: A function that applies Perspective transforms to a target named variable `image`.
+    """
+    if perspective_scale < 0.01:
+        return A.NoOp()
+
+    assert (
+        0.01 <= perspective_scale <= 0.2
+    ), "perspective_scale should be in [0.01..0.2]."
+    assert border_mode in [0, 1, 2, 3, 4], "border_mode should be in [0..4]."
+
+    return A.Perspective(
+        scale=perspective_scale,
+        keep_size=True,
+        pad_mode=border_mode,
+        always_apply=True,
+    )
+
+
+# NB: There is a stocastic effect here
+@def_operator(category=Category.Geometric)
+@param("scale", float, range=(0.0, 0.05))
+@param("num_rows", int, range=(2, 5), fixed=True, value=3)
+@param("num_cols", int, range=(2, 5), fixed=True, value=3)
+@param("interpolation", int, choices=(0, 1, 2, 3, 4, 5), fixed=True, value=2)
+@siso()
+@apply_albumentation()
+def PiecewiseAffine(
+    scale: float,
+    num_rows: int = 3,
+    num_cols: int = 3,
+    interpolation: int = 2,
+) -> Callable:
+    """Applies PiecewiseAffine transforms to an image.
+
+    Args:
+        scale (float): Each point on the regular grid is moved around via a normal distribution. This scale factor is equivalent to the normal distribution's sigma.
+        nbrows (int): Number of rows of points that the regular grid should have. Must be at least 2. For large images, you might want to pick a higher value than 4.
+        nbcols (int): Number of rows of points that the regular grid should have. Must be at least 2. For large images, you might want to pick a higher value than 4.
+        interpolation (int): The order of interpolation. The order has to be in the range 0-5:
+            - 0: Nearest-neighbor - 1: Bi-linear (default) - 2: Bi-quadratic - 3: Bi-cubic - 4: Bi-quartic - 5: Bi-quintic
+
+    Returns:
+        Callable: A function that applies PiecewiseAffine transforms to a target named variable `image`.
+    """
+    if scale < 0.01:
+        return A.NoOp()
+
+    assert num_rows >= 2, "num_rows must be at least 2"
+    assert num_cols >= 2, "num_cols must be at least 2"
+
+    return A.PiecewiseAffine(
+        scale=scale,
+        nb_rows=num_rows,
+        nb_cols=num_cols,
+        interpolation=interpolation,
+        always_apply=True,
+    )
+
+
+@def_operator(category=Category.Color)
+@param("sepia", bool, choices=(False, True))
+@siso()
+@apply_albumentation(filter_instances=False)
+def ToSepia(sepia: bool) -> Callable:
+    """Applies Sepia to an image. Sepia effect adds a warm brown tone to the image.
+
+    Args:
+        sepia (bool): Should the image have the sepia filter applied.
+
+    Returns:
+        Callable: A function that applies the Sepia operator to a target named variable `image`.
+    """
+    return A.ToSepia(p=0, always_apply=sepia)
+
+
+@def_operator(category=Category.Color)
+@param("gray", bool, choices=(False, True))
+@siso()
+@apply_albumentation(filter_instances=False)
+def ToGray(gray: bool) -> Callable:
+    """Applies grayscale to an image. If the mean pixel value for the resulting image is greater than 127, invert the resulting grayscale image.
+
+    Args:
+        gray (bool): Should the image have the grayscale filter applied.
+
+    Returns:
+        Callable: A function that applies the gray operator to a target named variable `image`.
+    """
+    return A.ToGray(p=0, always_apply=gray)
+
+
+@def_operator(category=Category.Noise)
+@param("iso_color_shift", float, range=(0, 1))
+@param("iso_intensity", float, range=(0, 1), fixed=True, value=0.5)
+@siso()
+@apply_albumentation(filter_instances=False)
+def ISONoise(iso_color_shift: float, iso_intensity: float = 0.25) -> Callable:
+    """Applies ISO Noise to an image.
+
+    Args:
+        iso_color_shift (float): Variance range for color hue change. Measured as a fraction of 360 degree Hue angle in HLS colorspace in (0, 1).
+        iso_intensity (float): Multiplicative factor that control strength of color and luminace noise.
+
+    Returns:
+        Callable: A function that applies ISO Noise operator to a target named variable `image`.
+    """
+    assert 0 <= iso_color_shift <= 1, "iso_color_shift should be [0, 1]."
+    assert 0 <= iso_intensity <= 1, "iso_intensity should be [0, 1]."
+
+    return A.ISONoise(
+        color_shift=(iso_color_shift, iso_color_shift),
+        intensity=(iso_intensity, iso_intensity),
+        always_apply=True,
+    )
+
+
+@def_operator(category=Category.Noise)
+@param("quality", int, range=(0, 100))
+@siso()
+@apply_albumentation(filter_instances=False)
+def JPEGCompression(quality: int) -> Callable:
+    """Applies Jpeg Compression to an image.
+
+    Args:
+        quality (int): Quality of the JPEG image in (0, 100).
+
+    Returns:
+        Callable: A function that applies Jpeg Compression operator to a target named variable `image`.
+    """
+    assert 0 <= quality <= 100, "quality operator should be [0, 100]."
+
+    return A.JpegCompression(
+        quality_lower=quality, quality_upper=quality, always_apply=True
+    )
+
+
+@def_operator(category=Category.Noise)
+@param("image_quality", int, range=(1, 100))
+@param("compression_type", str, choices=("jpg", "webp"), fixed=True, value="jpg")
+@siso()
+@apply_albumentation(filter_instances=False)
+def ImageCompression(image_quality: int, compression_type: int = 0) -> Callable:
+    """Applies Image Compression to an image.
+
+    Args:
+        image_quality (int): Quality of the compressed image in (1, 100).
+        compression_type (int): Choose between JPEG (value: 0, default) and WebP (value: 1).
+
+    Returns:
+        Callable: A function that applies Image Compression operator to a target named variable `image`.
+    """
+    compression_type_list = ["jpg", "webp"]
+    assert (
+        compression_type in compression_type_list
+    ), f"compression_type must be {compression_type_list}"
+    compression_type = compression_type_list.index(compression_type)
+
+    assert 0 < image_quality <= 100, "image_quality operator should be [1, 100]."
+
+    return A.ImageCompression(
+        quality_lower=image_quality,
+        quality_upper=image_quality,
+        compression_type=compression_type,
+        always_apply=True,
+    )
+
+
+@def_operator(category=Category.Noise)
+@param("clip_limit", float, range=(0.01, 3))
+@param("tile_grid_size", int, range=(3, 15))
+@siso()
+@apply_albumentation(filter_instances=False)
+def CLAHE(clip_limit: float, tile_grid_size: int = 0) -> Callable:
+    """Apply Contrast Limited Adaptive Histogram Equalization to the image.
+
+    Args:
+        clip_limit (float): Threshold value for contrast limiting in (0.01, 3).
+        tile_grid_size (int): threshold value for contrast limiting (size x size) in [3..15].
+
+    Returns:
+        Callable: A function that applies CLAHE operator to a target named variable `image`.
+    """
+    assert 0.01 <= clip_limit <= 3, "quality operator should be [0.01..3]."
+    assert 3 <= tile_grid_size <= 15, "tile_grid_size should be in [3..15]."
+
+    return A.CLAHE(
+        clip_limit=(clip_limit, clip_limit),
+        tile_grid_size=(tile_grid_size, tile_grid_size),
+        always_apply=True,
+    )
+
+
+@def_operator(category=Category.Noise)
+@param("equalize", bool, choices=(False, True))
+@param("mode", str, choices=("cv", "pil"), fixed=True, value="cv")
+@param("by_channels", bool, choices=(False, True), fixed=True, value=True)
+@siso()
+@apply_albumentation(filter_instances=False)
+def Equalize(equalize: bool, mode: str = "cv", by_channels: bool = True) -> Callable:
+    """Applies Equalization to an image historgram.
+
+    Args:
+        equalize (bool): Should the image be equalized.
+        model (str): Use OpenCV or PIL image function.
+        by_channels (bool): If True, use equalization by channels separately, else convert image to YCbCr representation and use equalization by Y channel.
+
+    Returns:
+        Callable: A function that applies Equalization operator to a target named variable `image`.
+    """
+    # assert 0 <= gray <= 1, "gray should be [0 or 1]."
+
+    return A.Equalize(p=0, mode=mode, by_channels=by_channels, always_apply=equalize)
+
+
+@def_operator(category=Category.Color)
+@param("num_bits", int, range=(1, 8))
+@siso()
+@apply_albumentation(filter_instances=False)
+def Posterize(num_bits: int) -> Callable:
+    """Applies Posterize to an image.
+
+    Args:
+        num_bits (int): Reduce the number of bits for each color channel. Values in [1, 8].
+
+    Returns:
+        Callable: A function that applies Posterize operator to a target named variable `image`.
+    """
+    assert 1 <= num_bits <= 8, "num_bits should be [1, 8]."
+
+    return A.Posterize(num_bits=num_bits, always_apply=True)
+
+
+# NB: There is a stocastic effect here.
+@def_operator(category=Category.Noise)
+@param("scale", float, range=(0, 0.5))
+@siso()
+@apply_albumentation(filter_instances=False)
+def ToneCurve(scale: float) -> Callable:
+    """Applies ToneCurve to an image.
+        Randomly change the relationship between bright and dark areas of the image by manipulating its tone curve.
+
+    Args:
+        scale (float): standard deviation of the normal distribution. Used to sample random
+            distances to move two control points that modify the image's curve. Values should be in range [0, 1].
+
+    Returns:
+        Callable: A function that applies ToneCurve operator to a target named variable `image`.
+    """
+    assert 0 <= scale <= 0.5, "scale operator should be [0, 0.5]."
+
+    return A.RandomToneCurve(scale=scale, always_apply=True)
+
+
+@def_operator(category=Category.Noise)
+@param("sharpen_alpha", float, range=(0, 1))
+@param("sharpen_lightness", float, range=(0, 1), fixed=True, value=1)
+@siso()
+@apply_albumentation(filter_instances=False)
+def Sharpen(sharpen_alpha: float, sharpen_lightness: float = 0.25) -> Callable:
+    """Applies Sharpen to an image.
+
+    Args:
+        sharpen_alpha (float): Visibility of the sharpened image. At 0, only the original image is visible, at 1.0 only its sharpened version is visible.
+        sharpen_lightness (float): Lightness of the sharpened image.
+
+    Returns:
+        Callable: A function that applies Sharpen operator to a target named variable `image`.
+    """
+    assert 0 <= sharpen_alpha <= 1, "sharpen_alpha should be [0, 1]."
+    assert 0 <= sharpen_lightness <= 1, "sharpen_lightness should be [0, 1]."
+
+    return A.Sharpen(
+        alpha=(sharpen_alpha, sharpen_alpha),
+        lightness=(sharpen_lightness, sharpen_lightness),
+        always_apply=True,
+    )
+
+
+@def_operator(category=Category.Color)
+@param("solarize_threshold", int, range=(0, 255))
+@siso()
+@apply_albumentation(filter_instances=False)
+def Solarize(solarize_threshold: int) -> Callable:
+    """Applies Solarize to an image.
+
+    Args:
+        solarize_threshold (int): Invert all pixel values above a threshold.
+
+    Returns:
+        Callable: A function that applies Solarize operator to a target named variable `image`.
+    """
+    assert 0 <= solarize_threshold <= 255, "solarize_threshold should be [0, 255]."
+
+    return A.Solarize(threshold=solarize_threshold, always_apply=True)
+
+
+@def_operator(category=Category.Image)
+@param("occlusion_areas", int, range=(0, 20), value=2)
+@param("max_height", float, range=(0, 1), fixed=True, value=0.1)
+@param("max_width", float, range=(0, 1), fixed=True, value=0.1)
+# @param("min_occlusion_areas", int, range=(0, 20), fixed=True, value=None)
+# @param("min_height", float, range=(0, 1), fixed=True, value=None)
+# @param("min_width", float, range=(0, 1), fixed=True, value=None)
+@param("occlusion_color", Color, range=((0, 255),) * 3, fixed=True, value=(128,) * 3)
+@siso()
+@apply_albumentation(filter_instances=False)
+def Occlusion(
+    occlusion_areas=8,
+    max_height=8,
+    max_width=8,
+    min_occlusion_areas=None,
+    min_height=None,
+    min_width=None,
+    occlusion_color=0,
+) -> Callable:
+    """Occlude part of an image with a target color.
+
+    Args:
+        occlusion_areas (float): Maximum number of occlusions to apply.
+        max_height (float): Height of the occluded area.
+        max_width (float): Width of the occluded area.
+        min_occlusion_areas (float): If specified, use the range between min and max occluded areas.
+        min_height (float): If specified, range the height of the occluded area.
+        min_width (float): If specified, range the width of the occluded area.
+        occlusion_color (Color): The tripple to use to fill in the occluded parts.
+
+    Returns:
+        Callable: Occlude part of the image for image, mask, keypoints,
+    """
+    if occlusion_areas < 1:
+        return A.NoOp()
+
+    if isinstance(occlusion_color, Color):
+        occlusion_color = [occlusion_color.r, occlusion_color.g, occlusion_color.b]
+
+    return A.CoarseDropout(
+        max_holes=occlusion_areas,
+        max_height=max_height,
+        max_width=max_width,
+        min_holes=min_occlusion_areas,
+        min_height=min_height,
+        min_width=min_width,
+        fill_value=occlusion_color,
+        mask_fill_value=None,
+        always_apply=True,
+    )
+
+
+@def_operator(category=Category.Weather)
+@param("fog_coef", float, range=(0, 0.65))
+@param("fog_alpha", float, range=(0, 1), fixed=True, value=0.25)
+@siso()
+@apply_albumentation(filter_instances=False)
+def Fog(fog_coef: float, fog_alpha: float) -> Callable:
+    """Applies Fog to an image.
+
+    Args:
+        fog_coef (float): The intensity of the fog. Should be in range [0..0.65].
+        fog_alpha (float): The transparency of the fog cloud. Should be in range [0..1].
+
+    Returns:
+        Callable: A function that applies the fog operator to a target named variable `image`.
+    """
+    if fog_coef < 1e-2:
+        return A.NoOp()
+
+    assert 1e-2 <= fog_coef <= 0.65, "Fog coef needs to be in the [0..0.65] range"
+    assert 0 <= fog_alpha <= 1, "Fog alpha needs to be in the [0..1] range"
+
+    # fog_coef = 0 causes RandomFog to hang indefinitely despite of:
+    # https://github.com/albumentations-team/albumentations/issues/361
+    return A.RandomFog(
+        fog_coef_lower=fog_coef,
+        fog_coef_upper=fog_coef,
+        alpha_coef=fog_alpha,
+        always_apply=True,
+    )
+
+
+@def_operator(category=Category.Weather)
+@param("snow_amount", float, range=(0, 1))
+@param("snow_brightness", float, range=(0.01, 3), fixed=True, value=1.0)
+@siso()
+@apply_albumentation(filter_instances=False)
+def Snow(snow_amount: float, snow_brightness: float) -> Callable:
+    """Adds snow to an image.
+
+    Args:
+        snow_amount (float): The amount of the snow. Should be in range [0..1].
+        snow_brightness (float): The brightness of the snow. Should be > 0.
+
+    Returns:
+        Callable: A function that adds snow to a target named variable `image`.
+    """
+    assert 0 <= snow_amount <= 1, "Snow amount must be in range [0..1]"
+    assert snow_brightness > 0, "Snow brightness should be >0."
+
+    return A.RandomSnow(
+        snow_point_lower=snow_amount,
+        snow_point_upper=snow_amount,
+        brightness_coeff=snow_brightness,
+        always_apply=True,
+    )
+
+
+@def_operator(category=Category.Weather)
+@param("flare_angle", float, range=(0, 1))
+@param("flare_cirles", int, range=(1, 8))
+@param("flare_rad", int, range=(10, 500), fixed=True, value=200)
+@param("flare_color", Color, range=((0, 255),) * 3, fixed=True, value=(255,) * 3)
+@siso()
+@apply_albumentation(filter_instances=False)
+def SunFlare(
+    flare_angle: float = 0.0,
+    flare_cirles: int = 1,
+    flare_rad: int = 200,
+    flare_color: Tuple[int, int, int] = (255, 255, 255),
+) -> Callable:
+    """Applies SunFlare to an image.
+
+    Args:
+        flare_roi (float, float, float, float): The region in the image where the flare will appear.
+            Top-left x,y, bottom right x, y. All values need to be within [0..1]
+        flare_angle (float): The angle of the flare. Should be in range [0..1].
+        flare_circles (int): The number of trailing flares. Should be > 0.
+        flare_rad (int): The radius of the flare. Should be > 0, in pixels.
+        flare_color (int, int, int): The RGB color of the flare.
+
+    Returns:
+        Callable: A function that applies the sun flare operator to a target named variable `image`.
+    """
+    flare_roi = Box(0, 0, 1, 1)
+    if isinstance(flare_roi, Box):
+        flare_roi = [flare_roi.tx, flare_roi.ty, flare_roi.bx, flare_roi.by]
+    if isinstance(flare_color, Color):
+        flare_color = [flare_color.r, flare_color.g, flare_color.b]
+
+    for flare_r in flare_roi:
+        assert 0 <= flare_r <= 1, "Flare_roi needs to be in the [0..1] range"
+    assert 0 <= flare_angle <= 1, "Flare_angle needs to be in the [0..1] range"
+    assert flare_cirles > 0, "Flare circles needs to be greater than 0."
+    assert flare_rad > 0, "Flare radius needs to be greater than 0."
+
+    flare_angle_lower = flare_angle - 0.01 if flare_angle != 0 else flare_angle
+    flare_angle_upper = flare_angle + 0.01 if flare_angle != 1 else flare_angle
+
+    return A.RandomSunFlare(
+        flare_roi=flare_roi,
+        angle_lower=flare_angle_lower,
+        angle_upper=flare_angle_upper,
+        num_flare_circles_lower=flare_cirles,
+        num_flare_circles_upper=flare_cirles + 1,
+        src_radius=flare_rad,
+        src_color=flare_color,
+        always_apply=True,
+    )
+
+
+@def_operator(category=Category.Weather)
+@param("shadow_num", int, range=(0, 5))
+@param("shadow_dimension", int, range=(2, 6), fixed=True, value=4)
+@siso()
+@apply_albumentation(filter_instances=False)
+def Shadow(
+    shadow_num: float = 1,
+    shadow_dimension: int = 4,
+) -> Callable:
+    """Applies Shadow to an image.
+
+    Args:
+        shadow_roi (float, float, float, float): The region in the image where the shadow will appear.
+            Top-left x,y, bottom right x, y. All values need to be within [0..1]
+        shadows_num (int): The number of shadows. Should be in range [0..5].
+        shadow_dimension (int): The number of edges in the shadow polygons. Should be in [2..6].
+
+    Returns:
+        Callable: A function that applies the shadow operator to a target named variable `image`.
+    """
+    shadow_roi = Box(0, 0, 1, 1)
+    if isinstance(shadow_roi, Box):
+        shadow_roi = [shadow_roi.tx, shadow_roi.ty, shadow_roi.bx, shadow_roi.by]
+
+    for shadow_r in shadow_roi:
+        assert 0 <= shadow_r <= 1, "shadow_roi needs to be in the [0..1] range"
+    assert 0 <= shadow_num <= 5, "shadows_num needs to be in the [0..5] range"
+    assert (
+        2 <= shadow_dimension <= 6
+    ), "shadow_dimension needs to be in the [2..6] range"
+
+    return A.RandomShadow(
+        shadow_roi=shadow_roi,
+        num_shadows_lower=shadow_num,
+        num_shadows_upper=shadow_num,
+        shadow_dimension=shadow_dimension,
+        always_apply=True,
+    )
+
+
+@def_operator(category=Category.Weather)
+@param("intensity", float, range=(0, 1))
+@param("mean", float, range=(0, 1), fixed=True, value=0.68)
+@param("std", float, range=(0.05, 1))
+@param("gauss_sigma", float, range=(0, 1))
+@param("cutout_threshold", float, range=(0, 1), fixed=True, value=0.5)
+@param("mode", str, choices=("rain", "mud"), fixed=True, value="rain")
+@siso()
+@apply_albumentation(filter_instances=False)
+def Spatter(
+    intensity: float,
+    mean: float,
+    std: float,
+    gauss_sigma: float,
+    cutout_threshold: float,
+    mode: str,
+) -> Callable:
+    """Applies Spatter to an image.
+
+    Args:
+        intensity (float): Intensity of corruption
+        mean (float): Mean value of normal distribution for generating liquid layer
+        std (float): Standard deviation value of normal distribution for generating liquid layer
+        gauss_sigma (float): Sigma value for gaussian filtering of liquid layer
+        cutout_threshold (float): Threshold for filtering liqued layer (determines number of drops)
+        mode (str): Type of corruption. Currently, supported options are 'rain' and 'mud'
+    Returns:
+        Callable: A function that applies the Spatter operator to a target named variable `image`.
+    """
+    if intensity == 0:
+        return A.NoOp()
+
+    return A.Spatter(
+        intensity=intensity,
+        mean=mean,
+        std=std,
+        gauss_sigma=gauss_sigma,
+        cutout_threshold=cutout_threshold,
+        mode=mode,
+        always_apply=True,
+    )
+
+
+@def_operator(category=Category.Common, source=True)
+@param("dataset", str, fixed=True, value="")
+@param("classes", list, fixed=True, value=[])
+@output()
+def ChooseImage(datapoint_id) -> Callable:
+    """Chooses an image from a dataset."""
+    return GenericNoOp()
+
+
+@def_operator(category=Category.Common, sink=True)
+@input()
+def EvaluateSample():
+    """Operator used to denote the output of the sample generation process."""
+    return lambda datapoint: (datapoint,)
+
+
+if __name__ == "__main__":
+    print(f"Avaliable operators: {METAMORPHS.keys()}")

--- a/efemarai/reports.py
+++ b/efemarai/reports.py
@@ -1,0 +1,85 @@
+import numpy as np
+from rich.table import Table
+
+from efemarai.console import console
+
+
+class RobustnessTestReport:
+    @staticmethod
+    def calculate_vulnerability(samples):
+        vulnerability = {}
+
+        params = samples.columns.tolist()
+        params.remove("score")
+        params.remove("image")
+
+        for param in params:
+            vulnerability[param] = samples.groupby(param)["score"].mean().mean()
+
+        return vulnerability
+
+    def __init__(self, samples):
+        self.samples = samples
+        self.vulnerability = self.calculate_vulnerability(samples)
+
+    def print_vulnerability(self):
+        table = Table(title="Robustness Test Report")
+        table.add_column("Axis", justify="center")
+        table.add_column("Vulnerability", justify="center")
+
+        for param, sensitivity in sorted(
+            self.vulnerability.items(),
+            key=lambda item: -item[1],
+        ):
+            table.add_row(param, f"{sensitivity:.4f}")
+
+        console.print(table)
+
+    def plot(self, filename=None):
+        import matplotlib.pyplot as plt
+
+        params = list(self.vulnerability.keys())
+        params.sort(key=lambda param: -self.vulnerability[param])
+
+        fig, axs = plt.subplots(
+            nrows=len(params),
+            figsize=(10, 4 * len(params)),
+            sharey=True,
+        )
+
+        axs[0].set_ylabel("Vulnerability")
+
+        for param, ax in zip(params, axs):
+            data = self.samples.groupby(param)["score"].apply(np.array)
+
+            ticks = data.index.to_numpy()
+
+            elements = ax.violinplot(
+                data.values,
+                ticks,
+                widths=0.12 / len(ticks),
+                showextrema=True,
+                showmeans=True,
+                showmedians=False,
+            )
+            ax.set_xticks(ticks)
+            ax.tick_params(axis="x", labelrotation=90)
+            ax.set_title(f"{param}: {self.vulnerability[param]:.4f}")
+
+            for name in ("cbars", "cmins", "cmaxes", "cmeans"):  # "cmedians",
+                elements[name].set_edgecolor("#00a9ff")
+                elements[name].set_linewidth(1)
+
+            for violin in elements["bodies"]:
+                violin.set_facecolor("#00a9ff")
+                violin.set_edgecolor("#00a9ff")
+                violin.set_linewidth(0)
+                violin.set_alpha(0.5)
+
+        fig.tight_layout()
+
+        if filename is None:
+            plt.show()
+        else:
+            plt.savefig(f"{filename}")
+            console.print(f":heavy_check_mark: Report plot saved as '{filename}'")

--- a/efemarai/spec.py
+++ b/efemarai/spec.py
@@ -1,0 +1,138 @@
+import re
+from functools import reduce
+
+
+class DictLiteral(dict):
+    pass
+
+
+class ListLiteral(list):
+    pass
+
+
+class TupleLiteral(tuple):
+    pass
+
+
+class CreateCall(tuple):
+    pass
+
+
+def convert(spec, xs):
+    """Converts data according to provided spec."""
+    env = {}
+    ys = eval(spec, xs, env)
+    return ys
+
+
+# Some syntactic sugar (rewriting macros)
+def call(*args, **kwargs):
+    """Escapes names of kwargs with a '."""
+    return *args, *(DictLiteral({"'" + name: value}) for name, value in kwargs.items())
+
+
+def create(*args, **kwargs):
+    if args[0] is dict:
+        return CreateCall(call(DictLiteral, **kwargs))
+
+    if args[0] is list:
+        return CreateCall(call(ListLiteral, *args[1:]))
+
+    if args[0] is tuple:
+        return CreateCall(call(TupleLiteral, *args[1:]))
+
+    return CreateCall(call(*args, **kwargs))
+
+
+def eval(term, x, env):
+    # Access data fields
+    if isinstance(term, str):
+        return eval_str(term, x, env)
+
+    # Handle literal data structs specified by the user
+    if type(term) is DictLiteral:
+        return {eval(name, x, env): eval(value, x, env) for name, value in term.items()}
+
+    if type(term) is ListLiteral:
+        return list(eval(item, x, env) for item in term)
+
+    if type(term) is TupleLiteral:
+        return tuple(eval(item, x, env) for item in term)
+
+    if isinstance(term, tuple):
+        # if first element is callable then call a function (a la LISP),
+        # otherwise perform eval on each element
+        if not callable(term[0]):
+            return tuple(eval(term, x, env) for term, x in zip(term, x))
+
+        return eval_call(term, x, env)
+
+    # Iterate over a list and process every element
+    if isinstance(term, list):
+        return [eval(term[0], item, env) for item in x]
+
+    # Data transformation
+    if isinstance(term, dict):
+        key, value = next(iter(term.items()), (None, None))
+
+        if isinstance(key, int):
+            key = f"[{key}]"
+
+        return eval(value, eval(key, x, env), env)
+
+    # Handle leaf functions as plain function application
+    if callable(term):
+        return term(x)
+
+    # Default to treating the term as a constant
+    return term
+
+
+def eval_str(term: str, x: any, env: dict):
+    # Escaped strings (i.e. 'str or 'str') are literals so return them
+    if term.startswith("'") and term.endswith("'"):
+        return term[1:-1]
+
+    if term.startswith("'"):
+        return term[1:]
+
+    # Find multiple accessors in a single string, e.g.
+    # '.instances[0].label.id' -> ['.instances', '[0]', '.label', '.id']
+    # '[0]bbox[1]' -> ['[0]', 'bbox', '[1]']
+    accessors = re.findall(r"\[[0-9]+\]|\.?[^\W0-9]\w+", term)
+
+    # Handle nested accessors
+    if len(accessors) > 1:
+        res = eval(accessors[0], x, env)
+        return eval("".join(accessors[1:]), res, env)
+
+    # Latest result (same as ipython)
+    if term == "_":
+        return x
+
+    # Class attribute access
+    if term.startswith("."):
+        return getattr(x, term[1:])
+
+    # Item access with [ ]
+    if term.startswith("[") and term.endswith("]"):
+        term = term[1:-1]
+
+    # Integer index access
+    if re.match(r"[-+]?\d+$", term) is not None:
+        term = int(term)
+
+    return x[term]
+
+
+def eval_call(term: tuple, x: any, env: dict):
+    fn, *rest = term
+    args, kwargs = [], {}
+
+    for arg in rest:
+        if type(arg) is DictLiteral:
+            kwargs.update(eval(arg, x, env))
+        else:
+            args.append(eval(arg, x, env))
+
+    return fn(*args, **kwargs)

--- a/examples/stress_test_pytorch_coco.py
+++ b/examples/stress_test_pytorch_coco.py
@@ -1,0 +1,48 @@
+import efemarai as ef
+
+from torchvision import datasets
+from torchvision.models.detection import (
+    FasterRCNN_ResNet50_FPN_V2_Weights,
+    fasterrcnn_resnet50_fpn_v2,
+)
+
+
+def main():
+    # To download the COCO dataset you could use the following steps:
+    #
+    # mkdir -p data/coco
+    # cd data/coco; \
+    # 	wget -c http://images.cocodataset.org/annotations/annotations_trainval2017.zip; \
+    # 	wget -c http://images.cocodataset.org/zips/val2017.zip; \
+    # 	unzip annotations_trainval2017.zip; \
+    # 	unzip val2017.zip;
+
+    path = "data/coco"
+
+    dataset = datasets.CocoDetection(
+        root=f"{path}/val2017",
+        annFile=f"{path}/annotations/instances_val2017.json",
+    )
+    dataset = [dataset[i] for i in range(5)]
+
+    weights = FasterRCNN_ResNet50_FPN_V2_Weights.DEFAULT
+    model = fasterrcnn_resnet50_fpn_v2(weights=weights, box_score_thresh=0.9)
+    model.cuda()
+    model.eval()
+
+    report = ef.test_robustness(
+        dataset=dataset,
+        model=lambda x: model(x.cuda().unsqueeze(0))[0],
+        domain=ef.domains.GeometricVariability,
+        dataset_format=ef.formats.COCO_DATASET,
+        output_format=ef.formats.TORCHVISION_DETECTION,
+        transform=weights.transforms(),
+        class_ids=range(100),
+        hooks=[ef.hooks.show_sample],
+    )
+
+    report.plot("robustness_report.pdf")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,9 @@ python-slugify>=6.1.2
 bson>=0.5.10
 ffmpeg-python>=0.2.0
 opencv-python-headless>=3.4.15.55
+
+
+# local testing
+hyperactive>=4.4.3
+albumentations>=1.3.0
+pandas>=1.5.0


### PR DESCRIPTION
Expose an API for local stress testing. Running `python examples/stress_test_pytorch_coco.py` should result in an output similar to
```
$python examples/stress_test_pytorch_coco.py
loading annotations into memory...   
Done (t=0.33s)                       
creating index...                    
index created!                       
       Robustness Test Report                   
┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓           
┃       Axis        ┃ Vulnerability ┃           
┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩           
│   affine_rotate   │    0.1639     │           
│ perspective_scale │    0.1536     │           
│       hflip       │    0.1513     │           
│   affine_scale    │    0.1427     │           
│   distort_limit   │    0.1313     │           
└───────────────────┴───────────────┘           
✔ Report plot saved as 'robustness_report.pdf'  

```