### PR TITLE
Add efemarai[full] extra package for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ If you work in the medical, aerospace and defence, security or ag domain, we pro
 
 ## Setup
 
-Install with
+Install full version with
 ```bash
-pip install -U efemarai
+pip install -U efemarai[full]
 ```
-then run
+or just base with `pip install -U efemarai`; then run
 ```bash
 efemarai init
 ```

--- a/efemarai/domains/__init__.py
+++ b/efemarai/domains/__init__.py
@@ -1,19 +1,22 @@
 import os
 
 from efemarai.definition_checker import DefinitionChecker
-from efemarai.metamorph.domain_loader import DomainLoader
 
+try:
+    from efemarai.metamorph.domain_loader import DomainLoader
 
-def load(filename, dataset=None):
-    definition = DefinitionChecker.load_definition(filename).get("domains")
+    def load(filename, dataset=None):
+        definition = DefinitionChecker.load_definition(filename).get("domains")
 
-    if definition is None or not definition:
-        return None
+        if definition is None or not definition:
+            return None
 
-    return DomainLoader.load(definition[0], dataset)
+        return DomainLoader.load(definition[0], dataset)
 
+    GeometricVariability = load(os.path.dirname(__file__) + "/geometric.yaml")
+    ColorVariability = load(os.path.dirname(__file__) + "/color.yaml")
+    NoiseVariability = load(os.path.dirname(__file__) + "/noise.yaml")
+    TextVariability = load(os.path.dirname(__file__) + "/text.yaml")
 
-GeometricVariability = load(os.path.dirname(__file__) + "/geometric.yaml")
-ColorVariability = load(os.path.dirname(__file__) + "/color.yaml")
-NoiseVariability = load(os.path.dirname(__file__) + "/noise.yaml")
-TextVariability = load(os.path.dirname(__file__) + "/text.yaml")
+except ImportError:
+    pass

--- a/efemarai/fields/annotation_fields.py
+++ b/efemarai/fields/annotation_fields.py
@@ -1,15 +1,15 @@
 from typing import Dict, List, Tuple
 
+import cv2
 import numpy as np
 import slugify
 from bson.objectid import ObjectId
 
 from efemarai.fields.base_fields import (
     BaseField,
-    sdk_serialize,
     create_polygons_from_mask,
+    sdk_serialize,
 )
-import cv2
 
 
 def chunks(lst, n):

--- a/efemarai/fields/base_fields.py
+++ b/efemarai/fields/base_fields.py
@@ -1,11 +1,11 @@
 import base64
+import itertools
 import json
 from typing import Dict, List
 
+import cv2
 import numpy as np
 from bson.objectid import ObjectId
-import cv2
-import itertools
 
 
 def _decode_ndarray(xs):
@@ -36,13 +36,11 @@ def _serialize_function(x):
         return str(x)
     return x.__dict__
 
+
 def create_polygons_from_mask(mask_img, threshold_value=127):
     # Get contours as polygons and the area of the polygons
     _, thresh = cv2.threshold(mask_img, threshold_value, 255, 0)
-    (
-        contours,
-        _,
-    ) = cv2.findContours(  # Format: [[[[x1, y1]], [[x2, y2]]...], ...]
+    (contours, _,) = cv2.findContours(  # Format: [[[[x1, y1]], [[x2, y2]]...], ...]
         thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
     )
     if not contours:

--- a/efemarai/fields/data_fields.py
+++ b/efemarai/fields/data_fields.py
@@ -9,8 +9,8 @@ from PIL import Image as pil_image
 from efemarai.fields.annotation_fields import AnnotationClass, InstanceField, Polygon
 from efemarai.fields.base_fields import (
     BaseField,
-    sdk_serialize,
     create_polygons_from_mask,
+    sdk_serialize,
 )
 
 

--- a/efemarai/fields/datapoint.py
+++ b/efemarai/fields/datapoint.py
@@ -6,6 +6,7 @@ from typing import Union
 
 import ffmpeg
 from bson.objectid import ObjectId
+
 from efemarai.console import console
 from efemarai.fields.annotation_fields import InstanceField, Polygon
 from efemarai.fields.base_fields import BaseField

--- a/efemarai/hooks.py
+++ b/efemarai/hooks.py
@@ -1,4 +1,4 @@
-from efemarai.fields import BoundingBox, Polygon, InstanceMask
+from efemarai.fields import BoundingBox, InstanceMask, Polygon
 
 
 def show_sample(

--- a/efemarai/metamorph/operators_registry.py
+++ b/efemarai/metamorph/operators_registry.py
@@ -4,5 +4,4 @@ import efemarai.metamorph.base_metamorphs as base
 import efemarai.metamorph.text.text_metamorphs
 import efemarai.metamorph.vision.vision_metamorphs
 
-
 METAMORPHS = base.METAMORPHS

--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -1,0 +1,9 @@
+hyperactive>=4.4.3
+albumentations>=1.3.0
+pandas>=1.2.0
+nltk>=3.8.1
+nlpaug>=1.1.11
+gensim>=4.0.1
+sacremoses>=0.0.53
+transformers>=4.16.2
+torchmetrics>=0.11.4

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ def get_version():
         raise RuntimeError("Unable to find version string.")
 
 
-def get_requirements():
-    with open("requirements.txt") as f:
+def get_requirements(file):
+    with open(file) as f:
         requirements = [
             line
             for line in f.read().splitlines()
@@ -48,7 +48,10 @@ setup(
     entry_points={
         "console_scripts": ["efemarai = efemarai.cli:main", "ef = efemarai.cli:main"]
     },
-    install_requires=get_requirements(),
+    install_requires=get_requirements("requirements.txt"),
+    extras_require={
+        "full": get_requirements("requirements_full.txt"),
+    },
     python_requires=">=3.6",
     zip_safe=False,
 )


### PR DESCRIPTION
In order to avoid unnecessary dependencies installs, let's have the `[full]` package take care of that. Here we warn the users if they call functionality with unmet dependencies (failures on imports) to install the full version.

We move those dependencies to `requirements_full.txt`.

Also fixes #10 